### PR TITLE
reproducing #173

### DIFF
--- a/main/test/mockit/integration/junit4/github173/AbstractReminderService.java
+++ b/main/test/mockit/integration/junit4/github173/AbstractReminderService.java
@@ -1,0 +1,19 @@
+/**
+ *
+ */
+package mockit.integration.junit4.github173;
+
+import java.util.Date;
+
+
+public abstract class AbstractReminderService implements IReminderService {
+    private final Long period;
+    private final long minimumSleepDurationInMs;
+
+    public AbstractReminderService(long minimumSleepDurationInMs, Long period) {
+        this.minimumSleepDurationInMs = minimumSleepDurationInMs;
+        this.period                   = period;
+    }
+
+
+}

--- a/main/test/mockit/integration/junit4/github173/AbstractService.java
+++ b/main/test/mockit/integration/junit4/github173/AbstractService.java
@@ -1,0 +1,20 @@
+package mockit.integration.junit4.github173;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+public abstract class AbstractService extends AbstractReminderService {
+
+    private final Logger LOGGER = Logger.getLogger(getClass().getName());
+    protected boolean isTestMode;
+    protected Environment currentEnvironment;
+
+    public AbstractService(long minimumSleepDurationInMs, boolean testModeSettingValue, Environment currentEnvironment, Long period) {
+        super(minimumSleepDurationInMs, period);
+        this.isTestMode         = testModeSettingValue;
+        this.currentEnvironment = currentEnvironment;
+    }
+
+
+}

--- a/main/test/mockit/integration/junit4/github173/AccountTwillio.java
+++ b/main/test/mockit/integration/junit4/github173/AccountTwillio.java
@@ -1,0 +1,30 @@
+package mockit.integration.junit4.github173;
+
+import java.io.*;
+import java.sql.SQLException;
+import java.util.*;
+
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AccountTwillio extends AbstractService {
+    private static final Logger LOGGER = Logger.getLogger(AccountTwillio.class.getName());
+    private DatabaseRemote maarsDb = null;
+    private AccountWhatever reminderServiceAccount = null;
+    private HttpClient httpClient = null;
+    private Clock clock = null;
+
+    public AccountTwillio(DatabaseRemote mAARSdb, HttpClient httpClient, AccountWhatever reminderServiceAccount,
+            Clock clock, long minimumSleepDurationInMs, boolean testModeSettingValue, Environment currentEnvironment) {
+
+        super(minimumSleepDurationInMs, testModeSettingValue, currentEnvironment, 1000L );
+        this.clock                  = clock;
+        this.maarsDb                = mAARSdb;
+        this.reminderServiceAccount = reminderServiceAccount;
+        this.httpClient             = httpClient;
+    }
+
+
+
+}

--- a/main/test/mockit/integration/junit4/github173/AccountWhatever.java
+++ b/main/test/mockit/integration/junit4/github173/AccountWhatever.java
@@ -1,0 +1,19 @@
+/**
+ *
+ */
+package mockit.integration.junit4.github173;
+
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+
+public class AccountWhatever  {
+
+}

--- a/main/test/mockit/integration/junit4/github173/Clock.java
+++ b/main/test/mockit/integration/junit4/github173/Clock.java
@@ -1,0 +1,14 @@
+package mockit.integration.junit4.github173;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class Clock {
+    public long getCurrentTime() {
+        return System.currentTimeMillis();
+    }
+}

--- a/main/test/mockit/integration/junit4/github173/DatabaseRemote.java
+++ b/main/test/mockit/integration/junit4/github173/DatabaseRemote.java
@@ -1,0 +1,14 @@
+package mockit.integration.junit4.github173;
+
+import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+import javax.ejb.Remote;
+import javax.persistence.EntityManager;
+import javax.persistence.LockModeType;
+
+public interface DatabaseRemote {
+
+}

--- a/main/test/mockit/integration/junit4/github173/Environment.java
+++ b/main/test/mockit/integration/junit4/github173/Environment.java
@@ -1,0 +1,5 @@
+package mockit.integration.junit4.github173;
+
+public enum Environment {
+    DEV, PROD, QA, STAGE
+}

--- a/main/test/mockit/integration/junit4/github173/GITHUB_ISSUE_173_parameter_names_not_available_Test.java
+++ b/main/test/mockit/integration/junit4/github173/GITHUB_ISSUE_173_parameter_names_not_available_Test.java
@@ -1,0 +1,59 @@
+package mockit.integration.junit4.github173;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+import mockit.Delegate;
+import mockit.Injectable;
+import mockit.Invocation;
+import mockit.NonStrictExpectations;
+import mockit.Tested;
+import mockit.Verifications;
+import mockit.integration.junit4.JMockit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Mocked;
+
+@RunWith(JMockit.class)
+public class GITHUB_ISSUE_173_parameter_names_not_available_Test {
+
+    @Injectable
+    private DatabaseRemote mAARSdb;
+
+    @Injectable
+    private HttpClient httpClient;
+
+    @Injectable
+    private AccountWhatever reminderServiceAccount;
+
+    @Injectable
+    private Clock clock;
+
+    @Injectable
+    private long minimumSleepDurationInMs;
+
+    @Injectable
+    private boolean testModeSettingValue;
+
+    @Injectable
+    private Environment currentEnvironment;
+
+    @Tested
+    private AccountTwillio accountTwillio;
+
+    public GITHUB_ISSUE_173_parameter_names_not_available_Test() {
+    }
+
+
+    @Test
+    public void test() throws Exception {
+
+
+    }
+
+
+}

--- a/main/test/mockit/integration/junit4/github173/HttpClient.java
+++ b/main/test/mockit/integration/junit4/github173/HttpClient.java
@@ -1,0 +1,5 @@
+package mockit.integration.junit4.github173;
+
+public class HttpClient {
+
+}

--- a/main/test/mockit/integration/junit4/github173/IReminderService.java
+++ b/main/test/mockit/integration/junit4/github173/IReminderService.java
@@ -1,0 +1,8 @@
+package mockit.integration.junit4.github173;
+
+import java.util.Date;
+
+
+public interface IReminderService {
+
+}

--- a/main/test/mockit/integration/junit4/github173/ServicesEJB.java
+++ b/main/test/mockit/integration/junit4/github173/ServicesEJB.java
@@ -1,0 +1,23 @@
+package mockit.integration.junit4.github173;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.ejb.Stateless;
+
+import javax.annotation.Resource;
+
+@Stateless
+public class ServicesEJB {
+
+    private final static Logger LOGGER = Logger.getLogger(ServicesEJB.class.getName());
+
+    @EJB
+    private DatabaseRemote maarsDb;
+    @EJB
+    private Clock clock;
+
+}


### PR DESCRIPTION
The issue can be reproduced by running:

```
> mvn test -Dtest=GITHUB_ISSUE_173_parameter_names_not_available_Test

# snip
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running mockit.integration.junit4.github173.GITHUB_ISSUE_173_parameter_names_not_available_Test
objc[42718]: Class JavaLaunchHelper is implemented in both /Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/jre/bin/java and /Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home/jre/lib/libinstrument.dylib. One of the two will be used. Which one is undefined.
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.426 sec <<< FAILURE! - in mockit.integration.junit4.github173.GITHUB_ISSUE_173_parameter_names_not_available_Test
test(mockit.integration.junit4.github173.GITHUB_ISSUE_173_parameter_names_not_available_Test)  Time elapsed: 0.054 sec  <<< ERROR!
java.lang.IllegalArgumentException: No constructor in tested class that can be satisfied by available injectables
  public mockit.integration.junit4.github173.AccountTwillio(mockit.integration.junit4.github173.DatabaseRemote,org.apache.http.client.HttpClient,mockit.integration.junit4.github173.AccountWhatever,mockit.integration.junit4.github173.Clock,long,boolean,mockit.integration.junit4.github173.Environment)
    disregarded because parameter names are not available
	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:264)
	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:153)
	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:124)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:200)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:153)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:103)


Results :

Tests in error:
  GITHUB_ISSUE_173_parameter_names_not_available_Test.test » IllegalArgument No ...

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1.870 s
[INFO] Finished at: 2015-05-16T11:48:22-04:00
[INFO] Final Memory: 16M/320M
```