### PR TITLE
Issue-243: Fixed ParameterNames.getSumOfArgumentSizes to properly count parameter slots

### DIFF
--- a/main/src/mockit/internal/state/ParameterNames.java
+++ b/main/src/mockit/internal/state/ParameterNames.java
@@ -64,7 +64,6 @@ public final class ParameterNames
 
       while (true) {
          char c = memberDesc.charAt(i);
-         i++;
 
          if (c == ')') {
             return sum;
@@ -76,11 +75,7 @@ public final class ParameterNames
          }
          else if (c == '[') {
             while ((c = memberDesc.charAt(i)) == '[') i++;
-
-            if (isDoubleSizeType(c)) { // if the array element type is double size...
-               i++;
-               sum++; // ...then count it here, otherwise let the outer loop count it
-            }
+            continue;
          }
          else if (isDoubleSizeType(c)) {
             sum += 2;
@@ -88,6 +83,7 @@ public final class ParameterNames
          else {
             sum++;
          }
+         i++;
       }
    }
 


### PR DESCRIPTION
This is a proposed fix for the referred issue.