### PR TITLE
Handle default protection domain

### DIFF
--- a/main/src/mockit/internal/expectations/injection/TestedClass.java
+++ b/main/src/mockit/internal/expectations/injection/TestedClass.java
@@ -20,7 +20,7 @@ final class TestedClass
       this.targetClass = targetClass;
       protectionDomainOfTestedClass = targetClass.getProtectionDomain();
       CodeSource codeSource = protectionDomainOfTestedClass.getCodeSource();
-      codeLocationParentPath = codeSource == null ? null : new File(codeSource.getLocation().getPath()).getParent();
+      codeLocationParentPath = codeSource == null || codeSource.getLocation() == null ? null : new File(codeSource.getLocation().getPath()).getParent();
       nameOfTestedClass = targetClass.getName();
    }
 


### PR DESCRIPTION
As some frameworks may re-define classes passed to JMockit via a custom ClassLoader for instance Robolectric 3.x with its InstrumentingClassLoader we need to consider default protection domains.

Refer to https://docs.oracle.com/javase/7/docs/api/java/lang/ClassLoader.html#defineClass(byte[],%20int,%20int). How the default protection domain is constructed. It does NOT contain a valid CodeSource reference, but it's instantiated.