### PR TITLE
Add xml output format

### DIFF
--- a/coverageTests/test/integrationTests/CoverageXmlTest.java
+++ b/coverageTests/test/integrationTests/CoverageXmlTest.java
@@ -1,0 +1,41 @@
+package integrationTests;
+
+import integrationTests.data.ClassWithFields;
+import mockit.coverage.CodeCoverage;
+import mockit.coverage.Configuration;
+import mockit.coverage.XmlFile;
+import mockit.coverage.data.CoverageData;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeThat;
+
+public class CoverageXmlTest extends CoverageTest {
+   ClassWithFields tested;
+
+   @Test
+   public void verifyXmlOutputGenerator() {
+      assumeThat(Configuration.getProperty("output"), is(equalTo("xml")));
+      assumeThat(Configuration.getProperty("outputDir"), is(equalTo("target")));
+      CodeCoverage.generateOutput(false);
+
+      File outputFile = new File("target", "coverage.xml");
+      assertTrue(outputFile.exists());
+   }
+
+   @Test
+   public void verifyXmlFile() throws IOException {
+      File outputFile = File.createTempFile("coverage_", ".xml", new File("target"));
+      outputFile.deleteOnExit();
+
+      new XmlFile("target", CoverageData.instance()).generate();
+
+      assertTrue(outputFile.exists());
+   }
+}

--- a/coverageTests/test/integrationTests/CoverageXmlTest.java
+++ b/coverageTests/test/integrationTests/CoverageXmlTest.java
@@ -6,27 +6,45 @@ import mockit.coverage.Configuration;
 import mockit.coverage.XmlFile;
 import mockit.coverage.data.CoverageData;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.Attributes;
+import org.xml.sax.HandlerBase;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.ext.DefaultHandler2;
+import org.xml.sax.helpers.DefaultHandler;
 
+import javax.xml.parsers.*;
 import java.io.File;
 import java.io.IOException;
 
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeThat;
 
-public class CoverageXmlTest extends CoverageTest {
+public class CoverageXmlTest extends CoverageTest
+{
    ClassWithFields tested;
 
    @Test
-   public void verifyXmlOutputGenerator() {
+   public void verifyXmlOutputGenerator()
+   {
+      File outputFile = new File("target", "coverage.xml");
+      if (outputFile.exists()) {
+         outputFile.delete();
+      }
       assumeThat(Configuration.getProperty("output"), is(equalTo("xml")));
       assumeThat(Configuration.getProperty("outputDir"), is(equalTo("target")));
+
       CodeCoverage.generateOutput(false);
 
-      File outputFile = new File("target", "coverage.xml");
       assertTrue(outputFile.exists());
+
+      outputFile.delete();
    }
 
    @Test

--- a/coverageTests/test/integrationTests/CoverageXmlTest.java
+++ b/coverageTests/test/integrationTests/CoverageXmlTest.java
@@ -48,7 +48,8 @@ public class CoverageXmlTest extends CoverageTest
    }
 
    @Test
-   public void verifyXmlFile() throws IOException {
+   public void verifyXmlFile() throws IOException
+   {
       File outputFile = File.createTempFile("coverage_", ".xml", new File("target"));
       outputFile.deleteOnExit();
 

--- a/main/src/mockit/coverage/OutputFileGenerator.java
+++ b/main/src/mockit/coverage/OutputFileGenerator.java
@@ -54,7 +54,7 @@ final class OutputFileGenerator
 
    private boolean isOutputWithCallPointsToBeGenerated()
    {
-      return hasOutputFormat("html") || hasOutputFormat("serial") || hasOutputFormat("serial-append") || hasOutputFormat("xml");
+      return hasOutputFormat("html") || hasOutputFormat("serial") || hasOutputFormat("serial-append");
    }
 
    boolean isWithCallPoints()

--- a/main/src/mockit/coverage/OutputFileGenerator.java
+++ b/main/src/mockit/coverage/OutputFileGenerator.java
@@ -54,7 +54,7 @@ final class OutputFileGenerator
 
    private boolean isOutputWithCallPointsToBeGenerated()
    {
-      return hasOutputFormat("html") || hasOutputFormat("serial") || hasOutputFormat("serial-append");
+      return hasOutputFormat("html") || hasOutputFormat("serial") || hasOutputFormat("serial-append") || hasOutputFormat("xml");
    }
 
    boolean isWithCallPoints()
@@ -107,6 +107,7 @@ final class OutputFileGenerator
 
       try {
          generateAccretionDataFileIfRequested(coverageData);
+         generateXmlFileIfRequested(coverageData);
          generateHTMLReportIfRequested(coverageData, outputDirCreated);
       }
       catch (IOException e) {
@@ -147,6 +148,13 @@ final class OutputFileGenerator
          AccretionFile accretionFile = new AccretionFile(outputDir, newData);
          accretionFile.mergeDataFromExistingFileIfAny();
          accretionFile.generate();
+      }
+   }
+
+   private void generateXmlFileIfRequested(@Nonnull CoverageData newData) throws IOException
+   {
+      if (hasOutputFormat("xml")) {
+         new XmlFile(outputDir, newData).generate();
       }
    }
 

--- a/main/src/mockit/coverage/XmlFile.java
+++ b/main/src/mockit/coverage/XmlFile.java
@@ -26,20 +26,32 @@ public class XmlFile
    @Nonnull private final CoverageData coverageData;
    private final List<String> srcDirs;
 
+   /**
+    * This constructor is used by the OutputFileGenerator.
+    */
    public XmlFile(String outputDir, CoverageData coverageData)
 	{
-      this.outputFile = new File(outputDir.isEmpty() ? null: outputDir, "coverage.xml");
-
-      coverageData.fillLastModifiedTimesForAllClassFiles();
-      this.coverageData = coverageData;
-      this.srcDirs = sourceDirectories();
+      this(new File(outputDir.isEmpty() ? null: outputDir, "coverage.xml"), null, coverageData);
 	}
 
-   private static List<String> sourceDirectories() {
+   /**
+    * This constructor can be used in test cases.
+    */
+   protected XmlFile(File outputFile, List<String> srcDirs, CoverageData coverageData)
+   {
+      this.outputFile = outputFile;
+      this.srcDirs = srcDirs == null ? sourceDirectories() : srcDirs;
+      coverageData.fillLastModifiedTimesForAllClassFiles();
+      this.coverageData = coverageData;
+   }
+
+   private static List<String> sourceDirectories()
+   {
       String srcDirs = Configuration.getProperty("srcDirs");
       if (srcDirs == null) {
          return Arrays.asList(System.getProperty("user.dir"));
-      } else {
+      }
+      else {
          List<String> srcDirList = Arrays.asList(srcDirs.split("\\s*,\\s*"));
          for (String dir : srcDirList) {
             File d = new File(dir);

--- a/main/src/mockit/coverage/XmlFile.java
+++ b/main/src/mockit/coverage/XmlFile.java
@@ -1,0 +1,75 @@
+package mockit.coverage;
+
+import mockit.coverage.data.CoverageData;
+import mockit.coverage.data.FileCoverageData;
+import mockit.coverage.lines.LineCoverageData;
+import mockit.coverage.lines.PerFileLineCoverage;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Map;
+
+/**
+ * enerates a xml file for Sonar Cube's Generic Test Coverage.
+ * http://docs.sonarqube.org/display/SONAR/Generic+Test+Coverage
+ */
+public class XmlFile
+{
+   @Nonnull private final File outputFile;
+   @Nonnull private final CoverageData coverageData;
+
+	private static final String XML_FORMAT_VERSION="1";
+
+   public XmlFile(String outputDir, CoverageData coverageData)
+	{
+      this.outputFile = new File(outputDir.isEmpty() ? null: outputDir, "coverage.xml");
+
+		coverageData.fillLastModifiedTimesForAllClassFiles();
+      this.coverageData = coverageData;
+	}
+   
+   /** Generates a report of the format:
+    * <pre>
+    * &lt;coverage version="1">
+    *    &lt;file path="src/main/java/com/example/MyClass.java">
+    *       &lt;lineToCover lineNumber="2" covered="false"/>
+    *       &lt;lineToCover lineNumber="3" covered="true" branchesToCover="8" coveredBranches="7"/>
+    *    &lt;/file>
+    * &lt;/coverage>
+    * </pre>
+    * TODO branch coverage is not yet implemented
+    */
+   public void generate() throws IOException
+	{
+	   outputFile.getAbsoluteFile().getParentFile().mkdirs();
+	   PrintStream xmlOut = null;
+	   try {
+	      xmlOut = new PrintStream(new FileOutputStream(outputFile), true, "UTF-8");
+			xmlOut.println("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
+	      xmlOut.printf("<coverage version=\"%s\">\n", XML_FORMAT_VERSION);
+	      for (Map.Entry<String, FileCoverageData> entry : this.coverageData.getFileToFileDataMap().entrySet()) {
+	         xmlOut.printf("<file path=\"src/%s\">\n", entry.getKey());
+	         PerFileLineCoverage lcinfo = entry.getValue().lineCoverageInfo;
+	         int maxlines = lcinfo.getLineCount();
+	         for (int i = 0; i <= maxlines; i++) {
+	            if (lcinfo.hasLineData(i)) {
+   	            LineCoverageData lineData = lcinfo.getLineData(i);
+   	            if (!lineData.isEmpty()) {
+   	               xmlOut.printf("<lineToCover lineNumber=\"%d\" covered=\"%b\"/>\n", i, lineData.isCovered());
+   	            }
+	            }
+	         }
+	         xmlOut.println("</file>");
+	      }
+	      xmlOut.println("</coverage>");
+	      System.out.println("JMockit: Coverage report written to " + outputFile.getCanonicalPath());
+	   } finally {
+	      if (xmlOut != null) {
+	         xmlOut.close();
+	      }
+	   }
+	}
+}


### PR DESCRIPTION
This is a new attempt to support an xml output format. 
This is version 1 which resembles the sonar xml format.
There are several roads one could take from here. JMockit could support several output format versions simultaneously or only one, update he format version and leave it to the tools reading the format to deal with the differences. 
Rogiero, I tried to compily with your requests from comment https://github.com/jmockit/jmockit1/pull/228#issuecomment-151511851 on a previous pull request and hope it is good enough to be accespted. Please don't hesitate to send any feedback on improvements. 
I couldn't make the code compile without PR #296.