### PR TITLE
Display arrays correctly in ParameterReflection.getParameterTypesDescription()

### DIFF
--- a/main/src/mockit/internal/util/ParameterReflection.java
+++ b/main/src/mockit/internal/util/ParameterReflection.java
@@ -18,7 +18,26 @@ public final class ParameterReflection
    static String getParameterTypesDescription(@Nonnull Type[] paramTypes)
    {
       String paramTypesDesc = Arrays.asList(paramTypes).toString();
-      return paramTypesDesc.replace("class ", "").replace('[', '(').replace(']', ')');
+      paramTypesDesc = paramTypesDesc
+              .replace("class ", "")
+              .replaceAll("\\[L([^;]*);", "$1[]")
+              .replace("[Z", "boolean[]")
+              .replace("[B", "byte[]")
+              .replace("[C", "char[]")
+              .replace("[D", "double[]")
+              .replace("[F", "float[]")
+              .replace("[I", "int[]")
+              .replace("[J", "long[]")
+              .replace("[S", "short[]")
+              .replaceFirst("\\[", "(")
+              .replaceFirst("\\]$", ")");
+      return replaceMultiDimensionArrays(paramTypesDesc);
+   }
+
+   @Nonnull
+   private static String replaceMultiDimensionArrays(@Nonnull String paramTypesDesc) {
+      String result = paramTypesDesc.replaceAll("\\[([^\\[\\] ]+)\\[", "$1[][");
+      return paramTypesDesc.equals(result) ? result : replaceMultiDimensionArrays(result);
    }
 
    @Nonnull

--- a/main/test/mockit/DeencapsulationTest.java
+++ b/main/test/mockit/DeencapsulationTest.java
@@ -385,6 +385,17 @@ public final class DeencapsulationTest
    }
 
    @Test
+   public void invokeInstanceMethodWithNonMatchingParameterTypes()
+   {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage(is(equalTo("No compatible method found: instanceMethod(java.util.ArrayList, java.lang.String[], " +
+            "boolean[], byte[][], char[][][], double[], float[], int[], long[], short[], java.lang.Object[][])")));
+
+      invoke(anInstance, "instanceMethod", new ArrayList<String>(), new String[0], new boolean[0], new byte[0][],
+              new char[0][][], new double[0], new float[0], new int[0], new long[0], new short[0], new Object[0][]);
+   }
+
+   @Test
    public void invokeStaticMethodWithoutParameters()
    {
       Boolean result = invoke(Subclass.class, "anStaticMethod");


### PR DESCRIPTION
When there are arrays or even worse multi-dimension arrays in the signature that gets transformed by `ParameterReflection.getParameterTypesDescription()`, the result is not really familiar. This PR fixes the displaying to be more like expected.