### PR TITLE
Verify that already loaded JMockit version is the expected version

### DIFF
--- a/main/test/mockit/VersionVerificationTest.java
+++ b/main/test/mockit/VersionVerificationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2006 Rogério Liesenfeld
+ * This file is subject to the terms of the MIT license (see LICENSE.txt).
+ */
+package mockit;
+
+import mockit.internal.startup.*;
+import org.junit.*;
+import org.junit.rules.*;
+import static mockit.Deencapsulation.*;
+import static mockit.internal.startup.Startup.*;
+
+public final class VersionVerificationTest
+{
+   @Rule public final ExpectedException thrown = ExpectedException.none();
+
+   @Test
+   public void checkVersionOnInitializeIfPossible()
+   {
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("JMockit with version '<already loaded version>' is already loaded in this JVM, JMockit with version '" + getField(Startup.class, "VERSION") + "' could not be loaded!");
+
+      String originalVersion = getField(Startup.class, "version");
+      try {
+         setField(Startup.class, "version", "<already loaded version>");
+         initializeIfPossible();
+      } finally {
+         setField(Startup.class, "version", originalVersion);
+      }
+   }
+
+   @Test
+   public void checkVersionOnVerifyInitialization()
+   {
+      thrown.expect(RuntimeException.class);
+      thrown.expectMessage("JMockit with version '<already loaded version>' is already loaded in this JVM, JMockit with version '" + getField(Startup.class, "VERSION") + "' could not be loaded!");
+
+      String originalVersion = getField(Startup.class, "version");
+      try {
+         setField(Startup.class, "version", "<already loaded version>");
+         verifyInitialization();
+      } finally {
+         setField(Startup.class, "version", originalVersion);
+      }
+   }
+}


### PR DESCRIPTION
This PR verifies that if a JMockit agent is already loaded in the current JVM, that it is the version expected. This prevents e. g. if you start a JVM with `-javaagent:jmockit-1.8.jar` but have `jmockit-1.24.jar` in your classpath to run your tests with that incompatibilites arise.

This also covers the case that you load JMockit in an application server to run integration tests from a branch using JMockit 1.8 and then run on the same application server instance integration tests from a branch using JMockit 1.24 without restarting the application server.