### PR TITLE
Set the hostClassName on MockingBridge from system classloader classes

### DIFF
--- a/main/src/mockit/internal/startup/Startup.java
+++ b/main/src/mockit/internal/startup/Startup.java
@@ -180,6 +180,12 @@ public final class Startup
                reapplyStartupMocks();
             }
          }
+
+         Class<?> initialMockingBridgeClass = ClassLoad.loadClass(systemCL, MockingBridge.class.getName());
+
+         if ((initialMockingBridgeClass != null) && (instrumentation != null)) {
+            MockingBridge.setHostClassName(FieldReflection.<String>getField(initialMockingBridgeClass, "hostClassName", null));
+         }
       }
 
       return instrumentation;

--- a/main/test/mockit/CustomClassLoadingTest.java
+++ b/main/test/mockit/CustomClassLoadingTest.java
@@ -9,6 +9,7 @@ import java.lang.reflect.*;
 import java.net.*;
 import javax.naming.*;
 
+import mockit.internal.*;
 import org.junit.*;
 import static org.junit.Assert.*;
 
@@ -123,5 +124,24 @@ public final class CustomClassLoadingTest
       currentThread.setContextClassLoader(new CustomCL(new CustomCL(originalCL)));
 
       new Collaborator();
+   }
+
+   @Test
+   public void ensureMockUpOnCustomClassLoaderCanBeInstantiated() throws Exception {
+      ClassLoader customClassLoader = new URLClassLoader(((URLClassLoader) ClassLoader.getSystemClassLoader()).getURLs(), null);
+
+      Constructor ctor = customClassLoader.loadClass(MockCollaborator.class.getName()).getDeclaredConstructor();
+      ctor.setAccessible(true);
+      ctor.newInstance();
+
+      ctor = customClassLoader.loadClass(Collaborator.class.getName()).getDeclaredConstructor();
+      ctor.setAccessible(true);
+      ctor.newInstance();
+
+      // restore the mocking bridge fields of this class loader as long as
+      // JMockit is not capable of running on multiple class loaders concurrently
+      // after that got fixed, this call can be removed and will additionally test
+      // this capability of JMockit
+      MockingBridge.setMockingBridgeFields();
    }
 }


### PR DESCRIPTION
With the new MockingBridgeFields handling you unfortunately missed the case of re-initialization under a custom classloader. This PR fixes the problem.