### PR TITLE
The temporary directory is filled with jmockit....jar files

### DIFF
--- a/main/src/mockit/internal/startup/PathToAgentJar.java
+++ b/main/src/mockit/internal/startup/PathToAgentJar.java
@@ -5,9 +5,16 @@
 package mockit.internal.startup;
 
 import java.io.*;
+import java.security.*;
+import java.util.*;
 import java.util.jar.*;
 import java.util.regex.*;
+import java.util.zip.*;
 import javax.annotation.*;
+
+import static java.io.File.createTempFile;
+import static java.lang.String.format;
+import static java.util.jar.JarFile.MANIFEST_NAME;
 
 import mockit.internal.*;
 
@@ -59,20 +66,126 @@ final class PathToAgentJar
 
       byte[] classFile = ClassFile.readFromFile(InstrumentationHolder.class).b;
 
-      try {
-         File tempJar = File.createTempFile("jmockit", ".jar");
-         tempJar.deleteOnExit();
+      FileOutputStream fos = null;
+      BufferedOutputStream bos = null;
+      DigestOutputStream dos = null;
+      JarOutputStream jos = null;
+      FileInputStream fis = null;
+      BufferedInputStream bis = null;
+      DigestInputStream dis = null;
+      try
+      {
+         // calculate MD5 hash of bootstrapping jar file
+         MessageDigest jarDigest = MessageDigest.getInstance("MD5");
+         ByteArrayOutputStream baos = new ByteArrayOutputStream();
+         dos = new DigestOutputStream(baos, jarDigest);
+         jos = new JarOutputStream(dos);
 
-         JarOutputStream output = new JarOutputStream(new FileOutputStream(tempJar), manifest);
-         JarEntry classEntry = new JarEntry(InstrumentationHolder.class.getName().replace('.', '/') + ".class");
-         output.putNextEntry(classEntry);
-         output.write(classFile);
-         output.close();
+         // write the manifest entry manually to be able to set the time
+         ZipEntry manifestEntry = new ZipEntry(MANIFEST_NAME);
+         // set the time to a fixed value, so that the generated JAR does not change each time
+         manifestEntry.setTime(0);
+         jos.putNextEntry(manifestEntry);
+         manifest.write(jos);
+         jos.closeEntry();
 
-         return tempJar.getPath();
+         ZipEntry classEntry = new ZipEntry(InstrumentationHolder.class.getName().replace('.', '/') + ".class");
+         // set the time to a fixed value, so that the generated JAR does not change each time
+         classEntry.setTime(0);
+         jos.putNextEntry(classEntry);
+         jos.write(classFile);
+         jos.closeEntry();
+         jos.close();
+
+         // check whether the file is already present, then do not use the newly created file
+         // this prevents overflowing of the temp directory with generated jar files and the try
+         // to replace a jar that may be locked by filesystem means like on Windows
+         byte[] digest = jarDigest.digest();
+         StringBuilder digestStringBuilder = new StringBuilder();
+         for (byte digestByte : digest)
+         {
+            digestStringBuilder.append(format("%02x", digestByte));
+         }
+         File jarFile = new File(System.getProperty("java.io.tmpdir"), format("jmockit-%s.jar", digestStringBuilder));
+         if (!jarFile.exists())
+         {
+            fos = new FileOutputStream(jarFile);
+            bos = new BufferedOutputStream(fos);
+            bos.write(baos.toByteArray());
+         }
+         else
+         {
+            jarDigest.reset();
+            fis = new FileInputStream(jarFile);
+            bis = new BufferedInputStream(fis);
+            dis = new DigestInputStream(bis, jarDigest);
+            while (dis.read() != -1);
+            fis.close();
+            if (!Arrays.equals(digest, jarDigest.digest()))
+            {
+               if (jarFile.delete())
+               {
+                  fos = new FileOutputStream(jarFile);
+                  bos = new BufferedOutputStream(fos);
+                  bos.write(baos.toByteArray());
+               }
+               else
+               {
+                  // create temp file
+                  File tempJarFile = createTempFile("jmockit_", ".jar");
+                  // as the JAR is used as agent JAR, this will not work on Oracle JVM currently,
+                  // but maybe it will work on other JVMs or later versions,
+                  // so leave this call here optimistically, at worst it has no effect
+                  tempJarFile.deleteOnExit();
+                  fos = new FileOutputStream(tempJarFile);
+                  bos = new BufferedOutputStream(fos);
+                  bos.write(baos.toByteArray());
+                  return tempJarFile.getPath();
+               }
+            }
+         }
+
+         return jarFile.getPath();
       }
-      catch (IOException e) {
+      catch (NoSuchAlgorithmException e)
+      {
+         // MD5 is not supported, this is against the specification
+         throw new AssertionError(e);
+      }
+      catch (IOException e)
+      {
          throw new RuntimeException(e);
+      }
+      finally
+      {
+         if (bos != null)
+         {
+            try { bos.close(); } catch (IOException ignore) {}
+         }
+         if (fos != null)
+         {
+            try { fos.close(); } catch (IOException ignore) {}
+         }
+         if (jos != null)
+         {
+            try { jos.close(); } catch (IOException ignore) {}
+         }
+         if (dos != null)
+         {
+            try { dos.close(); } catch (IOException ignore) {}
+         }
+         if (dis != null)
+         {
+            try { dis.close(); } catch (IOException ignore) {}
+         }
+         if (bis != null)
+         {
+            try { bis.close(); } catch (IOException ignore) {}
+         }
+         if (fis != null)
+         {
+            try { fis.close(); } catch (IOException ignore) {}
+         }
       }
    }
 }


### PR DESCRIPTION
If you use JMockit with WildFly using Attach API and the temp `jmockit....jar` file creation, the temp files are not cleaned, but each time you restart WildFly and thus JMockit gets loaded via Attach API afresh, a new `jmockit....jar` file is generated in the temporary folder and is never cleaned up. Those files are only 4 KiB in size, but over time they will still fill up the temporary directory unnecessarily.

I'd like to suggest adapting a part of my former pull-request, where the MD5 of the generated file is calculated and then the file is renamed to `jmockit-<MD5>.jar` if that file is not present already or has the wrong MD5 sum, and if it is present already with the correct MD5 sum, the new temp file should simply be deleted. Then as agent, the `jmockit-<MD5>.jar` file is used. This way only a new persistent temporary file is generated if the content, i. e. the `InstrumentationHolder` class got changed.