### PR TITLE
Spock and Groovy Support

### DIFF
--- a/main/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/main/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,1 @@
+mockit.integration.spock.JMockitExtension

--- a/main/pom.xml
+++ b/main/pom.xml
@@ -54,6 +54,7 @@
             <includes>
                <include>META-INF/services/org.junit.platform.engine.TestEngine</include>
                <include>META-INF/services/org.testng.ITestNGListener</include>
+               <include>META-INF/services/org.spockframework.runtime.extension.IGlobalExtension</include>
             </includes>
          </resource>
          <resource>
@@ -101,6 +102,29 @@
                <source>1.6</source><target>1.6</target>
                <compilerArgs><arg>-Xlint:none</arg></compilerArgs>
                <useIncrementalCompilation>false</useIncrementalCompilation>
+            </configuration>
+         </plugin>
+         <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+               <execution>
+                  <goals>
+                     <goal>addTestSources</goal>
+                     <goal>testCompile</goal>
+                  </goals>
+               </execution>
+            </executions>
+            <configuration>
+               <testSources>
+                  <testSource>
+                     <directory>${project.basedir}/test</directory>
+                     <includes>
+                        <include>**/*.groovy</include>
+                     </includes>
+                  </testSource>
+               </testSources>
             </configuration>
          </plugin>
          <plugin>
@@ -181,13 +205,15 @@
                   <configuration>
                      <skipTests>${skipTests}</skipTests>
                      <testNGArtifactName>none:none</testNGArtifactName>
+                     <includes>
+                        <include>**/*Test.class</include>
+                        <include>**/*Specification.class</include>
+                     </includes>
                      <excludes>
-                        <exclude>**/*$*</exclude>
                         <exclude>**/Base*Test.class</exclude>
                         <exclude>**/JUnit4DecoratorTest.class</exclude>
                         <exclude>**/testng/*Test.class</exclude>
                         <exclude>**/MockStateBetweenTestMethodsNGTest.class</exclude>
-                        <exclude>**/mockit/integration/TestedClass.class</exclude>
                      </excludes>
                   </configuration>
                </execution>
@@ -243,6 +269,10 @@
       </dependency>
       <dependency>
          <groupId>org.junit.jupiter</groupId><artifactId>junit-jupiter-engine</artifactId><version>5.0.0-M2</version>
+         <optional>true</optional>
+      </dependency>
+      <dependency>
+         <groupId>org.spockframework</groupId><artifactId>spock-core</artifactId><version>1.0-groovy-2.4</version>
          <optional>true</optional>
       </dependency>
       <dependency>

--- a/main/src/mockit/GroovyExpectations.java
+++ b/main/src/mockit/GroovyExpectations.java
@@ -1,0 +1,62 @@
+package mockit;
+
+import groovy.lang.*;
+import mockit.internal.expectations.transformation.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyExpectations extends Expectations implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyExpectations() {
+   }
+
+   protected GroovyExpectations(Object... classesOrObjectsToBePartiallyMocked) {
+      super(classesOrObjectsToBePartiallyMocked);
+   }
+
+   protected GroovyExpectations(Integer numberOfIterations, Object... classesOrObjectsToBePartiallyMocked) {
+      super(numberOfIterations, classesOrObjectsToBePartiallyMocked);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyInvocations.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyInvocations.handleSetProperty(name, value);
+
+      if ("result".equals(name)) {
+         ActiveInvocations.addResult(value);
+      }
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyFullVerifications.java
+++ b/main/src/mockit/GroovyFullVerifications.java
@@ -1,0 +1,61 @@
+package mockit;
+
+import groovy.lang.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyFullVerifications extends FullVerifications implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyFullVerifications() {
+   }
+
+   protected GroovyFullVerifications(int numberOfIterations) {
+      super(numberOfIterations);
+   }
+
+   protected GroovyFullVerifications(Object... mockedTypesAndInstancesToVerify) {
+      super(mockedTypesAndInstancesToVerify);
+   }
+
+   protected GroovyFullVerifications(Integer numberOfIterations, Object... mockedTypesAndInstancesToVerify) {
+      super(numberOfIterations, mockedTypesAndInstancesToVerify);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyVerifications.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyVerifications.handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyFullVerificationsInOrder.java
+++ b/main/src/mockit/GroovyFullVerificationsInOrder.java
@@ -1,0 +1,61 @@
+package mockit;
+
+import groovy.lang.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyFullVerificationsInOrder extends FullVerificationsInOrder implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyFullVerificationsInOrder() {
+   }
+
+   protected GroovyFullVerificationsInOrder(int numberOfIterations) {
+      super(numberOfIterations);
+   }
+
+   protected GroovyFullVerificationsInOrder(Object... mockedTypesAndInstancesToVerify) {
+      super(mockedTypesAndInstancesToVerify);
+   }
+
+   protected GroovyFullVerificationsInOrder(Integer numberOfIterations, Object... mockedTypesAndInstancesToVerify) {
+      super(numberOfIterations, mockedTypesAndInstancesToVerify);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyVerifications.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyVerifications.handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyInvocations.java
+++ b/main/src/mockit/GroovyInvocations.java
@@ -1,0 +1,57 @@
+package mockit;
+
+import java.util.*;
+import static java.util.Arrays.*;
+
+import groovy.lang.*;
+import mockit.internal.expectations.transformation.*;
+import mockit.internal.state.*;
+import org.codehaus.groovy.runtime.*;
+
+abstract class GroovyInvocations extends Invocations implements GroovyObject {
+   private static List<String> handledPropertyGetters = asList("any", "anyString", "anyInt", "anyBoolean", "anyLong", "anyDouble", "anyFloat", "anyChar", "anyShort", "anyByte");
+   private static List<String> handledPropertySetters = asList("times", "minTimes", "maxTimes");
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   static void handleGetProperty(String name) {
+      if (handledPropertyGetters.contains(name)) {
+         InvokerHelper.invokeStaticNoArgumentsMethod(ActiveInvocations.class, name);
+      }
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      if (handledPropertySetters.contains(name)) {
+         InvokerHelper.invokeStaticMethod(ActiveInvocations.class, name, value);
+      }
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyStrictExpectations.java
+++ b/main/src/mockit/GroovyStrictExpectations.java
@@ -1,0 +1,57 @@
+package mockit;
+
+import groovy.lang.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyStrictExpectations extends StrictExpectations implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyStrictExpectations() {
+   }
+
+   protected GroovyStrictExpectations(Object... classesOrObjectsToBePartiallyMocked) {
+      super(classesOrObjectsToBePartiallyMocked);
+   }
+
+   protected GroovyStrictExpectations(Integer numberOfIterations, Object... classesOrObjectsToBePartiallyMocked) {
+      super(numberOfIterations, classesOrObjectsToBePartiallyMocked);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyExpectations.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyExpectations.handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyVerifications.java
+++ b/main/src/mockit/GroovyVerifications.java
@@ -1,0 +1,53 @@
+package mockit;
+
+import groovy.lang.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyVerifications extends Verifications implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyVerifications() {
+   }
+
+   protected GroovyVerifications(int numberOfIterations) {
+      super(numberOfIterations);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyInvocations.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyInvocations.handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/GroovyVerificationsInOrder.java
+++ b/main/src/mockit/GroovyVerificationsInOrder.java
@@ -1,0 +1,53 @@
+package mockit;
+
+import groovy.lang.*;
+import org.codehaus.groovy.runtime.*;
+
+public abstract class GroovyVerificationsInOrder extends VerificationsInOrder implements GroovyObject {
+   private transient MetaClass metaClass = InvokerHelper.getMetaClass(getClass());
+
+   protected GroovyVerificationsInOrder() {
+   }
+
+   protected GroovyVerificationsInOrder(int numberOfIterations) {
+      super(numberOfIterations);
+   }
+
+   static void handleGetProperty(String name) {
+      GroovyVerifications.handleGetProperty(name);
+   }
+
+   static void handleSetProperty(String name, Object value) {
+      GroovyVerifications.handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object getProperty(String name) {
+      handleGetProperty(name);
+      return getMetaClass().getProperty(this, name);
+   }
+
+   @Override
+   public void setProperty(String name, Object value) {
+      handleSetProperty(name, value);
+   }
+
+   @Override
+   public Object invokeMethod(String name, Object args) {
+      return getMetaClass().invokeMethod(this, name, args);
+   }
+
+   @Override
+   public MetaClass getMetaClass() {
+      if (metaClass == null) {
+         metaClass = InvokerHelper.getMetaClass(getClass());
+      }
+
+      return metaClass;
+   }
+
+   @Override
+   public void setMetaClass(MetaClass metaClass) {
+      this.metaClass = metaClass;
+   }
+}

--- a/main/src/mockit/coverage/modification/ClassSelection.java
+++ b/main/src/mockit/coverage/modification/ClassSelection.java
@@ -112,6 +112,7 @@ final class ClassSelection
          className.startsWith("org.hamcrest.") ||
          className.startsWith("org.junit.") || className.startsWith("junit.") ||
          className.startsWith("org.testng.") ||
+         className.startsWith("org.spockframework.") || className.startsWith("spock.") ||
          className.startsWith("org.apache.maven.surefire.") ||
          ClassLoad.isGeneratedSubclass(className);
    }

--- a/main/src/mockit/integration/spock/JMockitExtension.java
+++ b/main/src/mockit/integration/spock/JMockitExtension.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2006 Rogério Liesenfeld
+ * This file is subject to the terms of the MIT license (see LICENSE.txt).
+ */
+package mockit.integration.spock;
+
+import java.lang.reflect.*;
+import javax.annotation.*;
+
+import mockit.integration.internal.*;
+import mockit.integration.junit4.internal.*;
+import mockit.internal.expectations.*;
+import mockit.internal.mockups.*;
+import mockit.internal.startup.*;
+import mockit.internal.state.*;
+import org.spockframework.runtime.extension.*;
+import org.spockframework.runtime.model.*;
+import spock.lang.*;
+import static mockit.internal.util.StackTrace.*;
+
+public final class JMockitExtension extends TestRunnerDecorator implements IGlobalExtension, IMethodInterceptor {
+
+   @Override
+   public void start() {
+      Startup.initializeIfPossible();
+   }
+
+   @Override
+   public void visitSpec(SpecInfo spec) {
+      spec.addInterceptor(this);
+      spec.addInitializerInterceptor(this);
+      for (FeatureInfo featureInfo : spec.getAllFeatures()) {
+         featureInfo.addIterationInterceptor(this);
+         featureInfo.getFeatureMethod().addInterceptor(this);
+      }
+   }
+
+   @Override
+   public void stop() {
+   }
+
+   public final void intercept(IMethodInvocation invocation) throws Throwable {
+      switch (invocation.getMethod().getKind()) {
+         case SPEC_EXECUTION:
+            interceptSpecExecution(invocation);
+            break;
+
+         case INITIALIZER:
+            interceptInitializerMethod(invocation);
+            break;
+
+         case ITERATION_EXECUTION:
+            interceptIterationExecution(invocation);
+            break;
+
+         case FEATURE:
+            interceptFeatureMethod(invocation);
+            break;
+
+         default:
+            throw new UnsupportedOperationException("intercepting for kind '" + invocation.getMethod().getKind() + "' is not implemented");
+      }
+   }
+
+   private void interceptSpecExecution(IMethodInvocation invocation) throws Throwable {
+      // Clean up, because if JUnit 4 and Spock tests are mixed, there might be some
+      // ghosts around from JUnit that would be cleaned up before the next test class,
+      // so do it here also, as mixing JUnit and Spock tests is a valid use-case
+      if (MockFrameworkMethod.hasDependenciesInClasspath()) {
+         clearFieldTypeRedefinitions();
+      }
+
+      SavePoint savePointForTestClass = new SavePoint();
+
+      Class<?> testClass = invocation.getInstance().getClass();
+      TestRun.setCurrentTestClass(testClass);
+
+      try {
+         invocation.proceed();
+      } finally {
+         savePointForTestClass.rollback();
+
+         clearFieldTypeRedefinitions();
+
+         // Do not do this if JUnit 4 is the parent runner, as accompanying
+         // JUnit tests would assume they are the first test to run and
+         // miss to do some cleanup
+         if (!MockFrameworkMethod.hasDependenciesInClasspath()) {
+            TestRun.setCurrentTestClass(null);
+         }
+      }
+   }
+
+   private void interceptInitializerMethod(IMethodInvocation invocation) throws Throwable {
+      invocation.proceed();
+
+      TestRun.enterNoMockingZone();
+
+      try {
+         handleMockFieldsForWholeTestClass(invocation.getInstance());
+      } finally {
+         TestRun.exitNoMockingZone();
+      }
+
+      TestRun.setRunningIndividualTest(invocation.getInstance(), true);
+   }
+
+   private void interceptIterationExecution(IMethodInvocation invocation) throws Throwable {
+      TestRun.prepareForNextTest();
+      TestRun.enterNoMockingZone();
+
+      SavePoint savePointForTest = new SavePoint();
+      try {
+         createInstancesForTestedFields(invocation.getInstance(), true);
+      } finally {
+         TestRun.exitNoMockingZone();
+      }
+
+      try {
+         invocation.proceed();
+      } finally {
+         savePointForTest.rollback();
+      }
+   }
+
+   private void interceptFeatureMethod(IMethodInvocation invocation) throws Throwable {
+      Method method = invocation.getMethod().getReflection();
+      Object testInstance = invocation.getInstance();
+
+      TestRun.enterNoMockingZone();
+
+      SavePoint savePointForTestMethod = new SavePoint();
+      try {
+         invocation.setArguments(createInstancesForMockParameters(method, invocation.getArguments()));
+         createInstancesForTestedFields(testInstance, false);
+      } finally {
+         TestRun.exitNoMockingZone();
+      }
+
+      TestRun.setRunningIndividualTest(testInstance, false);
+
+      Throwable thrownByTest = null;
+      try {
+         invocation.proceed();
+      } catch (Throwable throwable) {
+         thrownByTest = throwable;
+         throw throwable;
+      } finally {
+         TestRun.enterNoMockingZone();
+
+         thrownByTest = thrownByTest == null ? ((Specification) invocation.getInstance()).getSpecificationContext().getThrownException() : thrownByTest;
+
+         try {
+            savePointForTestMethod.rollback();
+
+            if (thrownByTest != null) {
+               filterStackTrace(thrownByTest);
+            }
+
+            Error expectationsFailure = RecordAndReplayExecution.endCurrentReplayIfAny();
+            clearTestedFieldsIfAny();
+
+            MockStates mockStates = TestRun.getMockStates();
+            try {
+               if (expectationsFailure == null && thrownByTest == null) {
+                  mockStates.verifyMissingInvocations();
+               }
+            } finally {
+               mockStates.resetExpectations();
+            }
+
+            if (thrownByTest == null && expectationsFailure != null) {
+               filterStackTrace(expectationsFailure);
+               throw expectationsFailure;
+            }
+         } finally {
+            TestRun.finishCurrentTestExecution();
+            TestRun.exitNoMockingZone();
+         }
+      }
+   }
+}

--- a/main/src/mockit/integration/spock/package-info.java
+++ b/main/src/mockit/integration/spock/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Provides integration with <em>Spock</em> test runners.
+ * Contains the {@link mockit.integration.spock.JMockitExtension} global extension.
+ * <p/>
+ * This integration provides the following benefits to test code:
+ * <ol>
+ * <li>
+ * Expected invocations specified through the Expectations or Mockups API are automatically verified before the
+ * execution of a test is completed.
+ * </li>
+ * <li>
+ * Mock-up classes applied with the Mockups API from inside a feature method or a setup method are discarded right
+ * after the execution of the test method or the whole test iteration, respectively.
+ * </li>
+ * <li>
+ * Feature methods accept <em>mock parameters</em>, whose values are mocked instances automatically created by
+ * JMockit and passed by the test runner when the feature method is executed.
+ * </li>
+ * </ol>
+ */
+package mockit.integration.spock;

--- a/main/src/mockit/internal/expectations/transformation/ExpectationsTransformer.java
+++ b/main/src/mockit/internal/expectations/transformation/ExpectationsTransformer.java
@@ -24,11 +24,17 @@ public final class ExpectationsTransformer implements ClassFileTransformer
    {
       baseSubclasses = new ArrayList<String>();
       baseSubclasses.add("mockit/Expectations");
+      baseSubclasses.add("mockit/GroovyExpectations");
       baseSubclasses.add("mockit/StrictExpectations");
+      baseSubclasses.add("mockit/GroovyStrictExpectations");
       baseSubclasses.add("mockit/Verifications");
+      baseSubclasses.add("mockit/GroovyVerifications");
       baseSubclasses.add("mockit/FullVerifications");
+      baseSubclasses.add("mockit/GroovyFullVerifications");
       baseSubclasses.add("mockit/VerificationsInOrder");
+      baseSubclasses.add("mockit/GroovyVerificationsInOrder");
       baseSubclasses.add("mockit/FullVerificationsInOrder");
+      baseSubclasses.add("mockit/GroovyFullVerificationsInOrder");
 
       Class<?>[] alreadyLoaded = instrumentation.getAllLoadedClasses();
       findAndModifyOtherBaseSubclasses(alreadyLoaded);
@@ -74,8 +80,10 @@ public final class ExpectationsTransformer implements ClassFileTransformer
    private static boolean isExpectationsOrVerificationsAPIClass(@Nonnull Class<?> aClass)
    {
       return
-         ("mockit.Expectations mockit.StrictExpectations mockit.Verifications mockit.FullVerifications " +
-          "mockit.VerificationsInOrder mockit.FullVerificationsInOrder").contains(aClass.getName());
+         ("mockit.Expectations mockit.GroovyExpectations mockit.StrictExpectations mockit.GroovyStrictExpectations " +
+          "mockit.Verifications mockit.GroovyVerifications mockit.FullVerifications mockit.GroovyFullVerifications " +
+          "mockit.VerificationsInOrder mockit.GroovyVerificationsInOrder " +
+          "mockit.FullVerificationsInOrder mockit.GroovyFullVerificationsInOrder").contains(aClass.getName());
    }
 
    private void modifyFinalSubclasses(@Nonnull Class<?>[] alreadyLoaded)
@@ -183,7 +191,7 @@ public final class ExpectationsTransformer implements ClassFileTransformer
          int i = baseSubclasses.indexOf(superName);
          boolean superClassIsKnownInvocationsSubclass = i >= 0;
 
-         if (i >= 2 && (i <= 5 || superName != null && superName.endsWith("Verifications"))) {
+         if (i >= 4 && (i <= 11 || superName != null && superName.endsWith("Verifications"))) {
             isVerificationsSubclass = true;
          }
 

--- a/main/src/mockit/internal/expectations/transformation/InvocationBlockModifier.java
+++ b/main/src/mockit/internal/expectations/transformation/InvocationBlockModifier.java
@@ -197,8 +197,10 @@ final class InvocationBlockModifier extends MethodVisitor
    {
       return
          blockOwner.equals(fieldOwner) ||
-         ("mockit/Expectations mockit/StrictExpectations mockit/Verifications mockit/VerificationsInOrder " +
-          "mockit/FullVerifications mockit/FullVerificationsInOrder").contains(fieldOwner);
+         ("mockit/Expectations mockit/GroovyExpectations mockit/StrictExpectations mockit/GroovyStrictExpectations " +
+          "mockit/Verifications mockit/GroovyVerifications mockit/VerificationsInOrder mockit/GroovyVerificationsInOrder " +
+          "mockit/FullVerifications mockit/GroovyFullVerifications " +
+          "mockit/FullVerificationsInOrder mockit/GroovyFullVerificationsInOrder").contains(fieldOwner);
    }
 
    private boolean generateCodeThatReplacesAssignmentToSpecialField(@Nonnull String fieldName)

--- a/main/src/mockit/internal/util/MethodReflection.java
+++ b/main/src/mockit/internal/util/MethodReflection.java
@@ -317,7 +317,7 @@ public final class MethodReflection
       for (Method declaredMethod : declaredMethods) {
          int methodModifiers = declaredMethod.getModifiers();
 
-         if (!isPrivate(methodModifiers) && !isStatic(methodModifiers)) {
+         if (!isPrivate(methodModifiers) && !isStatic(methodModifiers) && !declaredMethod.isSynthetic()) {
             if (found != null) {
                String methodType = Delegate.class.isAssignableFrom(handlerClass) ? "delegate" : "invocation handler";
                throw new IllegalArgumentException(

--- a/main/src/mockit/internal/util/StackTrace.java
+++ b/main/src/mockit/internal/util/StackTrace.java
@@ -75,7 +75,8 @@ public final class StackTrace
 
    private static boolean isTestFrameworkMethod(@Nonnull String where)
    {
-      return where.startsWith("org.junit.") || where.startsWith("org.testng.");
+      return where.startsWith("org.junit.") || where.startsWith("junit.") || where.startsWith("org.testng.")
+            || where.startsWith("org.spockframework.") || where.startsWith("spock.");
    }
 
    private static boolean isJMockitMethod(@Nonnull String where)

--- a/main/test/mockit/AssertionErrorMessagesSpecification.groovy
+++ b/main/test/mockit/AssertionErrorMessagesSpecification.groovy
@@ -1,0 +1,326 @@
+package mockit
+
+import mockit.internal.MissingInvocation
+import mockit.internal.UnexpectedInvocation
+import mockit.internal.expectations.RecordAndReplayExecution
+import mockit.internal.state.TestRun
+import spock.lang.Specification
+import spock.lang.Title
+
+@Title('Assertion Error Messages Specification')
+public final class AssertionErrorMessagesSpecification extends Specification {
+    @SuppressWarnings("GroovyUnusedDeclaration")
+    static class Collaborator {
+        void doSomething() {}
+
+        void doSomething(int i, String s) {}
+
+        void doSomethingElse(String s) {}
+    }
+
+    @Mocked
+    Collaborator mock
+
+    def 'unexpected invocation for recorded strict expectation'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomething anyInt, anyString
+                returns 5
+            }
+        }
+
+        when:
+        mock.doSomething 1, 'Abc'
+        mock.doSomething 2, 'xyz'
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 2, "xyz"'
+    }
+
+    def 'unexpected invocation where expecting another for recorded strict expectations'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomething anyInt, anyString
+                mock.doSomethingElse anyString
+            }
+        }
+
+        when:
+        mock.doSomething 1, 'Abc'
+        mock.doSomething 2, 'xyz'
+        mock.doSomethingElse 'test'
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 2, "xyz"'
+    }
+
+    def 'unexpected invocation for recorded strict expectation with maximum invocation count of zero'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomething anyInt, anyString
+                times = 0
+            }
+        }
+
+        when:
+        mock.doSomething 1, 'Abc'
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 1, "Abc"'
+    }
+
+    def 'unexpected invocation for recorded expectation'() {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.doSomething anyInt, anyString; times = 1
+            }
+        }
+
+        when:
+        mock.doSomething 1, 'Abc'
+        mock.doSomething 2, 'xyz'
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 2, "xyz"'
+    }
+
+    def 'unexpected invocation for verified expectation'() {
+        given:
+        mock.doSomething 123, 'Test'
+        mock.doSomethingElse 'abc'
+
+        when:
+        new GroovyVerifications() {
+            {
+                mock.doSomething withEqual(123), anyString
+                times = 0
+            }
+        }
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 123, "Test"'
+    }
+
+    def 'unexpected invocation for expectations verified in order'() {
+        given:
+        mock.doSomethingElse 'test'
+        mock.doSomething 123, 'Test'
+
+        when:
+        new GroovyVerificationsInOrder() {
+            {
+                mock.doSomethingElse anyString
+                mock.doSomething anyInt, anyString; times = 0
+            }
+        }
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'with arguments: 123, "Test"'
+    }
+
+    def 'unexpected first invocation for expectations partially verified in order'() {
+        given:
+        mock.doSomething(-5, 'abc')
+        mock.doSomethingElse 'test'
+        mock.doSomething 123, 'Test'
+
+        when:
+        new GroovyVerificationsInOrder() {
+            {
+                mock.doSomethingElse anyString
+                unverifiedInvocations()
+                mock.doSomething anyInt, anyString
+            }
+        }
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.toString().contains 'with arguments: "test"'
+        e.cause.toString().contains 'with arguments: -5, "abc"'
+    }
+
+    def "unexpected last invocation for expectations partially verified in order"() {
+        given:
+        mock.doSomethingElse 'test'
+        mock.doSomething 123, 'Test'
+        mock.doSomething(-5, 'abc')
+
+        when:
+        new GroovyVerificationsInOrder() {
+            {
+                mock.doSomethingElse anyString
+                unverifiedInvocations()
+                mock.doSomething withEqual(123), anyString
+            }
+        }
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.toString().contains 'with arguments: 123, "Test"'
+        e.cause.toString().contains 'with arguments: -5, "abc"'
+    }
+
+    def 'unexpected invocation after all others'() {
+        given:
+        mock.doSomethingElse 'Not verified'
+        mock.doSomething 1, 'anotherValue'
+        mock.doSomethingElse 'test'
+
+        and:
+        final Verifications v = new GroovyVerifications() {
+            {
+                mock.doSomething anyInt, anyString
+            }
+        }
+
+        when:
+        new GroovyVerificationsInOrder() {
+            {
+                unverifiedInvocations()
+                verifiedInvocations v
+            }
+        }
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.toString().contains 'with arguments: 1, "anotherValue"'
+        e.cause.toString().contains 'with arguments: "test"'
+    }
+
+    def 'unexpected invocation on method with no parameters'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomethingElse anyString
+            }
+        }
+
+        when:
+        mock.doSomething()
+
+        then:
+        UnexpectedInvocation e = thrown()
+        e.message.contains 'doSomething()\n   on instance'
+    }
+
+    def 'missing invocation for recorded strict expectation'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomething anyInt, anyString
+            }
+        }
+
+        when:
+        Error e = RecordAndReplayExecution.endCurrentReplayIfAny()
+
+        then:
+        e instanceof MissingInvocation
+        e.message.contains 'with arguments: any int, any String'
+    }
+
+    def 'missing invocation after recorded strict expectation which can occur one or more times'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.doSomethingElse anyString; maxTimes = -1
+                mock.doSomething withEqual(1), anyString
+            }
+        }
+
+        and:
+        mock.doSomethingElse 'Test'
+
+        when:
+        Error e = RecordAndReplayExecution.endCurrentReplayIfAny()
+
+        then:
+        e instanceof MissingInvocation
+        e.message.contains 'with arguments: 1, any String'
+
+        cleanup:
+        // satisfy the strict expectations so that the interceptor does not throw an exception
+        TestRun.getRecordAndReplayForRunningTest().replayPhase.positionOnFirstStrictExpectation()
+        mock.doSomethingElse ''
+        mock.doSomething 1, ''
+    }
+
+    def 'missing invocation for recorded expectation'() {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.doSomething anyInt, anyString; times = 2
+            }
+        }
+
+        and:
+        mock.doSomething 123, 'Abc'
+
+        when:
+        Error e = RecordAndReplayExecution.endCurrentReplayIfAny()
+
+        then:
+        e instanceof MissingInvocation
+        e.message.contains 'with arguments: any int, any String'
+
+        cleanup:
+        mock.doSomething 1, ''
+    }
+
+    def 'missing invocation for verified expectation'() {
+        when:
+        new GroovyVerifications() {
+            {
+                mock.doSomething withEqual(123), anyString
+            }
+        }
+
+        then:
+        MissingInvocation e = thrown()
+        e.message.contains 'with arguments: 123, any String'
+    }
+
+    def 'missing invocation for expectation verified in order'() {
+        given:
+        mock.doSomething 123, 'Test'
+
+        when:
+        new GroovyFullVerificationsInOrder() {
+            {
+                mock.doSomething anyInt, anyString
+                minTimes = 3
+            }
+        }
+
+        then:
+        MissingInvocation e = thrown()
+        e.message.contains 'with arguments: any int, any String'
+    }
+
+    def 'missing invocation for fully verified expectations'() {
+        given:
+        mock.doSomething 123, 'Abc'
+
+        when:
+        new GroovyFullVerifications() {
+            {
+                mock.doSomething anyInt, anyString
+                times = 2
+            }
+        }
+
+        then:
+        MissingInvocation e = thrown()
+        e.message.contains 'with arguments: any int, any String'
+    }
+}

--- a/main/test/mockit/CapturingImplementationsSpecification.groovy
+++ b/main/test/mockit/CapturingImplementationsSpecification.groovy
@@ -1,0 +1,244 @@
+package mockit
+
+import mockit.internal.ClassFile
+import spock.lang.Specification
+import spock.lang.Title
+
+import java.lang.management.ManagementFactory
+import java.lang.management.ThreadMXBean
+
+@Title('Capturing Implementations Specification')
+public final class CapturingImplementationsSpecification extends Specification {
+    interface ServiceToBeStubbedOut {
+        int doSomething()
+    }
+
+    // Just to cause any implementing classes to be stubbed out.
+    @Capturing
+    ServiceToBeStubbedOut unused
+
+    static final class ServiceLocator {
+        @SuppressWarnings("GroovyUnusedDeclaration")
+        static <S> S getInstance(Class<S> serviceInterface) {
+            new ServiceToBeStubbedOut() {
+                @Override
+                public int doSomething() { 10 }
+            } as S
+        }
+    }
+
+    def 'capture implementation loaded by service locator'() {
+        expect:
+        ServiceLocator.getInstance(ServiceToBeStubbedOut).doSomething() == 0
+    }
+
+    public interface Service1 {
+        int doSomething()
+    }
+
+    static final class Service1Impl implements Service1 {
+        @Override
+        public int doSomething() { 1 }
+    }
+
+    @Capturing
+    Service1 mockService1
+
+    def 'capture implementation using mock field'() {
+        given:
+        Service1 service = new Service1Impl()
+
+        and:
+        new GroovyExpectations() {
+            {
+                mockService1.doSomething()
+                returns 2, 3
+            }
+        }
+
+        expect:
+        service.doSomething() == 2
+        new Service1Impl().doSomething() == 3
+    }
+
+    public interface Service2 {
+        int doSomething()
+    }
+
+    static final class Service2Impl implements Service2 {
+        @Override
+        public int doSomething() { 1 }
+    }
+
+    def 'capture implementation using mock parameter'(@Capturing final Service2 mock) {
+        given:
+        Service2Impl service = new Service2Impl()
+
+        and:
+        new GroovyExpectations() {
+            {
+                mock.doSomething()
+                returns 3, 2
+            }
+        }
+
+        expect:
+        service.doSomething() == 3
+        new Service2Impl().doSomething() == 2
+    }
+
+    public abstract static class AbstractService {
+        protected abstract boolean doSomething()
+    }
+
+    static final class DefaultServiceImpl extends AbstractService {
+        @Override
+        protected boolean doSomething() { true }
+    }
+
+    def 'capture implementation of abstract class'(@Capturing AbstractService mock) {
+        expect:
+        !new DefaultServiceImpl().doSomething()
+        !new AbstractService() {
+            @Override
+            protected boolean doSomething() { throw new RuntimeException() }
+        }.doSomething()
+    }
+
+    def 'capture generated mock subclass'(@Capturing final AbstractService mock1, @Mocked final AbstractService mock2) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock1.doSomething(); result = true
+                mock2.doSomething(); result = false
+            }
+        }
+
+        expect:
+        !mock2.doSomething()
+        mock1.doSomething()
+        new DefaultServiceImpl().doSomething()
+    }
+
+    static final Class<? extends Service2> customLoadedClass = new ClassLoader() {
+        @Override
+        protected Class<? extends Service2> findClass(String name) {
+            byte[] bytecode = ClassFile.readFromFile(name.replace('.', '/')).b
+            defineClass name, bytecode, 0, bytecode.length
+        }
+    }.findClass Service2Impl.name
+
+    final Service2 service2 = Deencapsulation.newInstance customLoadedClass
+
+    def 'capture class previously loaded by class loader other than context'(@Capturing final Service2 mock) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.doSomething(); result = 15
+            }
+        }
+
+        expect:
+        service2.doSomething() == 15
+    }
+
+    @Capturing
+    ServiceDoSomething mockService2
+
+    def setupSpec() {
+        ServiceDoSomething.ServiceDoSomethingProvider.proxyInstance =
+                ServiceDoSomething.ServiceDoSomethingProvider.newProxyClassAndInstance ServiceDoSomething, Serializable
+    }
+
+    def 'capture dynamically generated proxy class'() {
+        expect:
+        ServiceDoSomething.ServiceDoSomethingProvider.proxyInstance.doSomething() == 0
+
+        when:
+        new GroovyExpectations() {
+            {
+                mockService2.doSomething(); result = 123
+            }
+        }
+
+        then:
+        ServiceDoSomething.ServiceDoSomethingProvider.proxyInstance.doSomething() == 123
+        ServiceDoSomething.ServiceDoSomethingProvider.newProxyClassAndInstance(ServiceDoSomething).doSomething() == 123
+    }
+
+    interface Interface {
+        void op()
+    }
+
+    interface SubInterface extends Interface {}
+
+    static class Implementation implements SubInterface {
+        @Override
+        public void op() { throw new RuntimeException() }
+    }
+
+    def 'capture class implementing sub interface of captured interface'(@Capturing Interface base) {
+        when:
+        new Implementation().op()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'capture classes from the java management api'(@Capturing ThreadMXBean anyThreadMXBean) {
+        given:
+        ThreadMXBean threadingBean = ManagementFactory.threadMXBean
+
+        expect:
+        threadingBean.threadCount == 0
+    }
+
+    interface Interface2 {
+        int doSomething()
+    }
+
+    interface SubInterface2 extends Interface2 {}
+
+    static class ClassImplementingSubInterfaceAndExtendingUnrelatedBase extends Implementation implements SubInterface2 {
+        @Override
+        public int doSomething() { 123 }
+    }
+
+    def 'capture class which implements captured base interface and extends unrelated base'(
+            @Capturing Interface2 captured) {
+        expect:
+        new ClassImplementingSubInterfaceAndExtendingUnrelatedBase().doSomething() == 0
+    }
+
+    static class Base<T> {
+        T doSomething() { null }
+
+        void doSomething(T t) { println 'test' }
+    }
+
+    static final class Impl extends Base<Integer> {
+        @Override
+        Integer doSomething() { 1 }
+
+        @Override
+        void doSomething(Integer i) {}
+    }
+
+    def 'capture implementations of generic type'(@Capturing final Base<Integer> anyInstance) {
+        given:
+        new GroovyExpectations() {
+            {
+                anyInstance.doSomething(); result = 2
+                anyInstance.doSomething 0
+            }
+        }
+
+        when:
+        Base<Integer> impl = new Impl()
+        int i = impl.doSomething()
+        impl.doSomething 0
+
+        then:
+        i == 2
+    }
+}

--- a/main/test/mockit/CapturingInstancesSpecification.groovy
+++ b/main/test/mockit/CapturingInstancesSpecification.groovy
@@ -1,0 +1,312 @@
+/*
+ * Copyright (c) 2006 Rogério Liesenfeld
+ * This file is subject to the terms of the MIT license (see LICENSE.txt).
+ */
+package mockit
+
+import spock.lang.Specification
+import spock.lang.Title
+
+import java.util.concurrent.Callable
+
+@Title('Capturing Instances Specification')
+public final class CapturingInstancesSpecification extends Specification {
+    public interface Service1 {
+        int doSomething()
+    }
+
+    static final class Service1Impl implements Service1 {
+        @Override
+        public int doSomething() { 1 }
+    }
+
+    public static final class TestedUnit {
+        private final Service1 service1 = new Service1Impl()
+        private final Service1 service2 = new Service1() {
+            @Override
+            public int doSomething() { 2 }
+        }
+        Observable observable
+
+        public int businessOperation(final boolean b) {
+            new Callable() {
+                @Override
+                public Object call() { throw new IllegalStateException() }
+            }.call()
+
+            observable = new Observable() {
+                {
+                    if (b) {
+                        throw new IllegalArgumentException()
+                    }
+                }
+            }
+
+            service1.doSomething() + service2.doSomething()
+        }
+    }
+
+    @Capturing(maxInstances = 2)
+    Service1 service
+
+    def 'capture service instances created by tested constructor'() {
+        given:
+        TestedUnit unit = new TestedUnit()
+
+        expect:
+        unit.service1.doSomething() == 0
+        unit.service2.doSomething() == 0
+    }
+
+    def 'capture all internally created instances'(@Capturing Observable observable, @Capturing Callable callable) {
+        given:
+        new GroovyExpectations() {
+            {
+                service.doSomething(); returns 3, 4
+            }
+        }
+
+        and:
+        TestedUnit unit = new TestedUnit();
+
+        expect:
+        unit.businessOperation(true) == 7
+        unit.service1.doSomething() == 4
+        unit.service2.doSomething() == 4
+        unit.observable
+
+        and:
+        when:
+        new GroovyVerifications() {
+            {
+                callable.call()
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    public interface Service2 {
+        int doSomething()
+    }
+
+    static final class Service2Impl implements Service2 {
+        @Override
+        public int doSomething() { 2 }
+    }
+
+    def 'record strict expectations for next two instances to be created'(
+            @Capturing(maxInstances = 1) final Service2 s1, @Capturing(maxInstances = 1) final Service2 s2) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                s1.doSomething(); result = 11
+                s2.doSomething(); returns 22, 33
+            }
+        }
+
+        and:
+        Service2Impl service1 = new Service2Impl()
+        Service2Impl service2 = new Service2Impl()
+
+        expect:
+        service1.doSomething() == 11
+        service2.doSomething() == 22
+        service2.doSomething() == 33
+    }
+
+    def 'record expectations for next two instances to be created'(
+            @Capturing(maxInstances = 1) final Service2 mock1, @Capturing(maxInstances = 1) final Service2 mock2) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock1.doSomething(); result = 11
+                mock2.doSomething(); result = 22
+            }
+        }
+
+        and:
+        Service2Impl s1 = new Service2Impl()
+        Service2Impl s2 = new Service2Impl()
+
+        expect:
+        s2.doSomething() == 22
+        s1.doSomething() == 11
+        s1.doSomething() == 11
+        s2.doSomething() == 22
+        s1.doSomething() == 11
+    }
+
+    def 'record expectations for next two instances of two different implementing classes'(
+            @Capturing(maxInstances = 1) final Service2 mock1, @Capturing(maxInstances = 1) final Service2 mock2) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock1.doSomething(); result = 1
+                mock2.doSomething(); result = 2
+            }
+        }
+
+        and:
+        Service2 s1 = new Service2() {
+            @Override
+            public int doSomething() { -1 }
+        }
+        Service2 s2 = new Service2() {
+            @Override
+            public int doSomething() { -2 }
+        }
+
+        expect:
+        s1.doSomething() == 1
+        s2.doSomething() == 2
+    }
+
+    def 'record expectations for two consecutive sets of future instances'(
+            @Capturing(maxInstances = 2) final Service2 set1, @Capturing(maxInstances = 3) final Service2 set2) {
+        given:
+        new GroovyExpectations() {
+            {
+                set1.doSomething(); result = 1
+                set2.doSomething(); result = 2
+            }
+        }
+
+        and: 'First set of instances, matching the expectation on "set1"'
+        Service2 s1 = new Service2Impl();
+        Service2 s2 = new Service2Impl();
+
+        and: 'Second set of instances, matching the expectation on "set2"'
+        Service2 s3 = new Service2Impl();
+        Service2 s4 = new Service2Impl();
+        Service2 s5 = new Service2Impl();
+
+        and: 'Third set of instances, not matching any expectation'
+        Service2 s6 = new Service2Impl();
+
+        expect:
+        s1.doSomething() == 1
+        s2.doSomething() == 1
+
+        and:
+        s3.doSomething() == 2
+        s4.doSomething() == 2
+        s5.doSomething() == 2
+
+        and:
+        s6.doSomething() == 0
+    }
+
+    def 'record expectations for next two instances to be created using mock parameters'(
+            @Capturing(maxInstances = 1) final Service2 s1, @Capturing(maxInstances = 1) final Service2 s2) {
+        given:
+        new GroovyExpectations() {
+            {
+                s2.doSomething(); result = 22
+                s1.doSomething(); result = 11
+            }
+        }
+
+        and:
+        Service2Impl cs1 = new Service2Impl();
+        Service2Impl cs2 = new Service2Impl();
+
+        expect:
+        cs1.doSomething() == 11
+        cs2.doSomething() == 22
+        cs1.doSomething() == 11
+        cs2.doSomething() == 22
+    }
+
+    static class Base {
+        boolean doSomething() { false }
+    }
+
+    static final class Derived1 extends Base {}
+
+    static final class Derived2 extends Base {
+        Service2 doSomethingElse() { null }
+    }
+
+    def 'verify expectations only on first of two captured instances'(@Capturing(maxInstances = 1) final Base b) {
+        given:
+        new GroovyExpectations() {
+            {
+                b.doSomething(); result = true; times = 1
+            }
+        }
+
+        expect:
+        new Derived1().doSomething()
+        !new Derived2().doSomething()
+    }
+
+    def 'verify expectations only on one of two subclasses for two captured instances'(
+            @Capturing(maxInstances = 1) final Derived1 firstCapture,
+            @Capturing(maxInstances = 1) final Derived1 secondCapture) {
+        given:
+        new GroovyExpectations() {
+            {
+                new Derived1(); times = 2
+                firstCapture.doSomething(); result = true; times = 1
+                secondCapture.doSomething(); result = true; times = 1
+            }
+        }
+
+        expect:
+        new Derived1().doSomething()
+        !new Derived2().doSomething()
+        new Derived1().doSomething()
+    }
+
+    def 'capture subclass and cascade from method exclusive to subclass'(@Capturing Base capturingMock) {
+        given:
+        Derived2 d = new Derived2()
+
+        expect:
+        // Classes mocked only because they implement / extend a capturing base type do not cascade from methods
+        // that exist only in them.
+        d.doSomethingElse() == null
+    }
+
+    abstract class Buffer {
+        abstract int position()
+    }
+
+    class ByteBuffer extends Buffer {
+        int position() { 1 }
+    }
+
+    class IntBuffer extends Buffer {
+        int position() { 2 }
+    }
+
+    class CharBuffer extends Buffer {
+        int position() { 3 }
+    }
+
+    // cannot use java.nio.Buffer as original Java test, because added Groovy magic
+    // does load some classes which creates various Buffer-subclass instances
+    // this works against the maxInstances count and thus custom objects are used
+    def 'specify different behavior for first new instance and for remaining new instances'(
+            @Capturing(maxInstances = 1) final Buffer firstNewBuffer, @Capturing final Buffer remainingNewBuffers) {
+        given:
+        new GroovyExpectations() {
+            {
+                firstNewBuffer.position(); result = 10
+                remainingNewBuffers.position(); result = 20
+            }
+        }
+
+        when:
+        ByteBuffer buffer1 = new ByteBuffer()
+        IntBuffer buffer2 = new IntBuffer()
+        CharBuffer buffer3 = new CharBuffer()
+
+        then:
+        buffer1.position() == 10
+        buffer2.position() == 20
+        buffer3.position() == 20
+    }
+}

--- a/main/test/mockit/CascadingFieldSpecification.groovy
+++ b/main/test/mockit/CascadingFieldSpecification.groovy
@@ -1,0 +1,458 @@
+package mockit
+
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.lang.Title
+
+@Title('Cascading Field Specification')
+public final class CascadingFieldSpecification extends Specification {
+    static class Foo {
+        Bar getBar() { null }
+
+        static Bar globalBar() { null }
+
+        void doSomething(String s) { throw new RuntimeException(s) }
+
+        int getIntValue() { 1 }
+
+        Boolean getBooleanValue() { true }
+
+        String getStringValue() { 'abc' }
+
+        public final Date getDate() { null }
+
+        final List<Integer> getList() { null }
+    }
+
+    static class Bar {
+        Bar() { throw new RuntimeException() }
+
+        int doSomething() { 1 }
+
+        boolean isDone() { false }
+
+        Short getShort() { 1 }
+
+        List<?> getList() { null }
+
+        Baz getBaz() { null }
+
+        Runnable getTask() { null }
+    }
+
+    static final class Baz {
+        final E e
+
+        Baz(E e) { this.e = e }
+
+        E getE() { e }
+
+        void doSomething() {}
+    }
+
+    public enum E {
+        A, B
+    }
+
+    public interface A {
+        B getB()
+    }
+
+    public interface B {
+        C getC()
+    }
+
+    public interface C {}
+
+    @Mocked
+    Foo foo
+    @Mocked
+    A a
+
+    def setup() {
+        new GroovyExpectations() {
+            {
+                Bar bar = foo.getBar(); minTimes = 0
+                bar.isDone(); result = true; minTimes = 0
+            }
+        }
+    }
+
+    def 'obtain cascaded instances at all levels'() {
+        expect:
+        foo.bar
+        foo.bar.list != null
+        foo.bar.baz
+        foo.bar.task
+
+        and:
+        when:
+        B b = a.b
+
+        then:
+        b
+        b.c
+    }
+
+    def 'obtain cascaded instances at all levels again'() {
+        when:
+        Bar bar = foo.bar
+
+        then:
+        bar
+        bar.list != null
+        bar.baz
+        bar.task
+
+        and:
+        expect:
+        a.b
+        a.b.c
+    }
+
+    def 'cascade one level'() {
+        expect:
+        foo.bar.done
+        foo.bar.doSomething() == 0
+        Foo.globalBar().doSomething() == 0
+        !Foo.globalBar().is(foo.bar)
+        foo.bar.short.intValue() == 0
+
+        and:
+        when:
+        foo.doSomething 'test'
+
+        then:
+        noExceptionThrown()
+
+        and:
+        expect:
+        foo.intValue == 0
+        !foo.booleanValue
+        foo.stringValue == null
+        foo.date
+        foo.list.isEmpty()
+
+        and:
+        when:
+        new GroovyVerifications() {
+            {
+                foo.doSomething anyString
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'exercise cascading mock again'() {
+        expect:
+        foo.bar.done
+    }
+
+    def 'record unambiguous strict expectations producing different cascaded instances'() {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                Bar c1 = Foo.globalBar()
+                c1.isDone(); result = true
+                Bar c2 = Foo.globalBar()
+                c2.doSomething(); result = 5
+                if (c1.is(c2)) {
+                    throw new AssertionError('c1 and c2 should be different')
+                }
+            }
+        }
+
+        when:
+        Bar b1 = Foo.globalBar()
+
+        then:
+        b1.done
+
+        and:
+        when:
+        Bar b2 = Foo.globalBar()
+
+        then:
+        b2.doSomething() == 5
+
+        and:
+        !b1.is(b2)
+    }
+
+    def 'record unambiguous non strict expectations producing different cascaded instances'(
+            @Mocked final Foo foo1, @Mocked final Foo foo2) {
+        given:
+        new GroovyExpectations() {
+            {
+                Date c1 = foo1.getDate()
+                Date c2 = foo2.getDate()
+                if (c1.is(c2)) {
+                    throw new AssertionError('c1 and c2 should be different')
+                }
+            }
+        }
+
+        when:
+        Date d1 = foo1.date
+        Date d2 = foo2.date
+
+        then:
+        !d1.is(d2)
+    }
+
+    def 'record ambiguous expectations on instance method producing the same cascaded instance'() {
+        given:
+        new GroovyExpectations() {
+            {
+                Bar c1 = foo.getBar()
+                Bar c2 = foo.getBar()
+                if (!c1.is(c2)) {
+                    throw new AssertionError('c1 and c2 should be identical')
+                }
+            }
+        }
+
+        when:
+        Bar b1 = foo.bar
+        Bar b2 = foo.bar
+
+        then:
+        b1.is b2
+    }
+
+    def 'record ambiguous expectations on static method producing the same cascaded instance'() {
+        given:
+        new GroovyExpectations() {
+            {
+                Bar c1 = Foo.globalBar()
+                Bar c2 = Foo.globalBar()
+                if (!c1.is(c2)) {
+                    throw new AssertionError('c1 and c2 should be identical')
+                }
+            }
+        }
+
+        when:
+        Bar b1 = Foo.globalBar()
+        Bar b2 = Foo.globalBar()
+
+        then:
+        b1.is b2
+    }
+
+    static final class AnotherFoo {
+        Bar getBar() { null }
+    }
+    @Mocked
+    AnotherFoo anotherFoo
+
+    def 'cascading mock field'() {
+        given:
+        new GroovyExpectations() {
+            {
+                anotherFoo.getBar().doSomething(); result = 123
+            }
+        }
+
+        expect:
+        new AnotherFoo().bar.doSomething() == 123
+    }
+
+    def 'cascading instance accessed from delegate method'() {
+        given:
+        new GroovyExpectations() {
+            {
+                foo.getIntValue()
+                result = new Delegate() {
+                    @Mock
+                    int delegate() { foo.bar.doSomething() }
+                }
+            }
+        }
+
+        expect:
+        foo.intValue == 0
+    }
+
+    @Mocked
+    BazCreatorAndConsumer bazCreatorAndConsumer
+
+    static class BazCreatorAndConsumer {
+        Baz create() { null }
+
+        void consume(Baz arg) { arg.toString() }
+    }
+
+    def 'call method on non cascaded instance from custom argument matcher with cascaded instance also created'() {
+        when:
+        Baz nonCascadedInstance = new Baz(E.A)
+        Baz cascadedInstance = bazCreatorAndConsumer.create()
+
+        then:
+        !nonCascadedInstance.is(cascadedInstance)
+
+        when:
+        bazCreatorAndConsumer.consume(nonCascadedInstance);
+
+        and:
+        new GroovyVerifications() {
+            {
+                bazCreatorAndConsumer.consume(with(new Delegate<Baz>() {
+                    boolean matches(Baz actual) { actual.e.is E.A }
+                }))
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    // Tests for cascaded instances obtained from generic methods //////////////////////////////////////////////////////
+
+    static class GenericBaseClass1<T> {
+        T getValue() { null }
+    }
+
+    def 'cascade generic method from specialized generic class'(@Mocked GenericBaseClass1<C> mock) {
+        expect:
+        mock.value
+    }
+
+    static class ConcreteSubclass1 extends GenericBaseClass1<A> {}
+
+    def 'cascade generic method of concrete subclass which extends generic class'(
+            @Mocked final ConcreteSubclass1 mock) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.getValue().getB().getC()
+                result = new C() {}
+            }
+        }
+
+        expect:
+        A value = mock.value
+        value
+        B b = value.b
+        b
+        b.c
+
+        and:
+        when:
+        new GroovyFullVerificationsInOrder() {
+            {
+                mock.value.b.c
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    interface Ab extends A {}
+
+    static class GenericBaseClass2<T extends A> {
+        T getValue() { null }
+    }
+
+    static class ConcreteSubclass2 extends GenericBaseClass2<Ab> {}
+
+    def 'cascade generic method of subclass which extends generic class with upper bound using interface'(
+            @Mocked final ConcreteSubclass2 mock) {
+        given:
+        Ab value = mock.value
+
+        expect:
+        value
+        value.b.c
+
+        and:
+        when:
+        new GroovyVerifications() {
+            {
+                mock.value.b.c; times = 1
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade generic method of subclass which extends generic class with upper bound only in verification block'(
+            @Mocked final ConcreteSubclass2 mock) {
+        when:
+        new GroovyFullVerifications() {
+            {
+                Ab value = mock.value; times = 0
+                B b = value.b; times = 0
+                b.c; times = 0
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    static final class Action implements A {
+        @Override
+        public B getB() { null }
+    }
+
+    static final class ActionHolder extends GenericBaseClass2<Action> {}
+
+    def 'cascade generic method of subclass which extends generic class with upper bound using class'(
+            @Mocked final ActionHolder mock) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.value.b.c
+            }
+        }
+
+        when:
+        mock.value.b.c
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Stepwise
+    @Title('Cascading Field Sub Specification')
+    public static final class CascadingFieldSubSpecification extends Specification {
+        class Base<T extends Serializable> {
+            T value() { 123 as T }
+        }
+
+        class Derived1 extends Base<Long> {}
+
+        class Derived2 extends Base<Long> {}
+
+        interface Factory1 {
+            Derived1 get1()
+        }
+
+        interface Factory2 {
+            Derived2 get2()
+        }
+
+        @Mocked
+        Factory1 factory1
+        @Mocked
+        Factory2 factory2
+
+        def 'use subclass mocked through cascading'() {
+            expect:
+            factory1.get1().value() == 0L // cascade-mocks Derived1 (per-instance)
+            new Derived1().value() == 123L // new instance, not mocked
+        }
+
+        def 'use subclass previously mocked through cascading while mocking sibling subclass'(@Injectable Derived2 d2) {
+            expect:
+            new Derived1().value() == 123L
+            d2.value() == 0L
+            new Derived2().value() == 123L
+        }
+    }
+}

--- a/main/test/mockit/CascadingParametersSpecification.groovy
+++ b/main/test/mockit/CascadingParametersSpecification.groovy
@@ -1,0 +1,822 @@
+package mockit
+
+import mockit.internal.UnexpectedInvocation
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Stepwise
+import spock.lang.Title
+
+import java.lang.management.CompilationMXBean
+import java.lang.management.ManagementFactory
+import java.nio.channels.SocketChannel
+
+@Title('Cascading Parameters Specification')
+public final class CascadingParametersSpecification extends Specification {
+    static class Foo {
+        Bar getBar() { null }
+
+        static Bar globalBar() { null }
+
+        void doSomething(String s) { throw new RuntimeException(s) }
+
+        int getIntValue() { 1 }
+
+        Boolean getBooleanValue() { true }
+
+        final List<Integer> getList() { null }
+
+        HashMap<?, ?> getMap() { null }
+    }
+
+    static class Bar {
+        Bar() { throw new RuntimeException() }
+
+        int doSomething() { 1 }
+
+        Baz getBaz() { null }
+
+        Baz getBaz(int i) { null }
+
+        AnEnum getEnum() { null }
+
+        static String staticMethod() { 'notMocked' }
+    }
+
+    static final class SubBar extends Bar {}
+
+    public interface Baz {
+        void runIt()
+
+        Date getDate()
+    }
+
+    enum AnEnum {
+        First, Second, Third
+    }
+
+    @Stepwise
+    @Title('Cascading Parameters Sub Specification')
+    public static final class CascadingParametersSubSpecification extends Specification {
+        @Shared
+        Bar cascadedBar1
+        @Shared
+        Bar cascadedBar2
+
+        def 'cascade one level during replay'(@Mocked Foo foo) {
+            given:
+            cascadedBar1 = foo.bar
+            cascadedBar2 = Foo.globalBar()
+
+            expect:
+            cascadedBar1.doSomething() == 0
+            cascadedBar2.doSomething() == 0
+
+            and:
+            when:
+            Bar bar = foo.bar
+
+            then:
+            bar.is cascadedBar1
+
+            and:
+            when:
+            Bar globalBar = Foo.globalBar()
+
+            then:
+            globalBar.is cascadedBar2
+            !globalBar.is(bar)
+
+            and:
+            when:
+            foo.doSomething 'test'
+
+            then:
+            noExceptionThrown()
+
+            and:
+            expect:
+            foo.intValue == 0
+            !foo.booleanValue
+            foo.list.isEmpty()
+            foo.map == null
+        }
+
+        def 'verify that previous cascaded instances have been discarded'(@Mocked Foo foo) {
+            given:
+            Bar bar = foo.bar
+            Bar globalBar = Foo.globalBar()
+
+            expect:
+            cascadedBar1
+            !bar.is(cascadedBar1)
+            cascadedBar2
+            !globalBar.is(cascadedBar2)
+        }
+    }
+
+    def 'verify that static methods and constructors are not mocked when cascading'(@Mocked Foo foo) {
+        given:
+        foo.bar
+
+        expect:
+        Bar.staticMethod() == 'notMocked'
+
+        and:
+        when:
+        new Bar()
+
+        then:
+        thrown RuntimeException
+    }
+
+    def 'verify that static methods and constructors are mocked when cascaded mock is mocked normally'(
+            @Mocked Foo mockFoo, @Mocked Bar mockBar) {
+        expect:
+        mockFoo.bar.is mockBar
+        mockBar.doSomething() == 0
+        Bar.staticMethod() == null
+
+        and:
+        when:
+        new Bar()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'use available mocked instance of subclass as cascaded instance'(@Mocked Foo foo, @Mocked SubBar bar) {
+        expect:
+        foo.bar.is bar
+    }
+
+    def 'replace cascaded instance with first one of two injectable instances'(
+            @Mocked final Foo foo, @Injectable final Bar bar1, @Injectable Bar bar2) {
+        given:
+        new GroovyExpectations() {
+            {
+                foo.getBar(); result = bar1
+            }
+        }
+
+        expect:
+        foo.bar.is bar1
+        bar1.doSomething() == 0
+        bar2.doSomething() == 0
+    }
+
+    def 'cascade one level during record'(@Mocked final Foo mockFoo) {
+        given:
+        final List<Integer> list = [1, 2, 3]
+
+        and:
+        new GroovyExpectations() {
+            {
+                mockFoo.doSomething anyString; minTimes = 2
+                mockFoo.getBar().doSomething(); result = 2
+                Foo.globalBar().doSomething(); result = 3
+                mockFoo.getBooleanValue(); result = true
+                mockFoo.getIntValue(); result = -1
+                mockFoo.getList(); result = list
+            }
+        }
+
+        and:
+        Foo foo = new Foo()
+
+        when:
+        foo.doSomething '1'
+
+        then:
+        noExceptionThrown()
+
+        and:
+        expect:
+        foo.bar.doSomething() == 2
+
+        and:
+        when:
+        foo.doSomething '2'
+
+        then:
+        noExceptionThrown()
+
+        and:
+        expect:
+        Foo.globalBar().doSomething() == 3
+        foo.booleanValue
+        foo.intValue == -1
+        foo.list.is list
+    }
+
+    def 'cascade one level during verify'(@Mocked final Foo foo) {
+        given:
+        Bar bar = foo.bar
+        bar.doSomething()
+        bar.doSomething()
+        Foo.globalBar().doSomething()
+
+        expect:
+        foo.intValue == 0
+        !foo.booleanValue
+        foo.list.isEmpty()
+
+        and:
+        when:
+        new GroovyVerifications() {
+            {
+                foo.bar.doSomething(); minTimes = 2
+                Foo.globalBar().doSomething(); times = 1
+            }
+        }
+
+        and:
+        new GroovyVerificationsInOrder() {
+            {
+                foo.intValue
+                foo.booleanValue
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade two levels during replay'(@Mocked Foo foo) {
+        when:
+        foo.bar.baz.runIt()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade two levels during record'(@Mocked final Foo mockFoo) {
+        given:
+        new GroovyExpectations() {
+            {
+                mockFoo.getBar().doSomething(); result = 1
+                Foo.globalBar().doSomething(); result = 2
+
+                mockFoo.getBar().getBaz().runIt(); times = 2
+            }
+        }
+
+        and:
+        Foo foo = new Foo()
+
+        expect:
+        foo.bar.doSomething() == 1
+        Foo.globalBar().doSomething() == 2
+
+
+        and:
+        when:
+        Baz baz = foo.bar.baz
+        baz.runIt()
+        baz.runIt()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade one level and verify invocation on last mock only'(@Mocked Foo foo, @Injectable final Bar bar) {
+        given:
+        Bar fooBar = foo.bar
+
+        expect:
+        fooBar.is bar
+
+        and:
+        when:
+        fooBar.doSomething()
+
+        and:
+        new GroovyVerifications() {
+            {
+                bar.doSomething()
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade two levels with invocation recorded on last mock only'(@Mocked Foo foo, @Mocked final Baz baz) {
+        given:
+        new GroovyExpectations() {
+            {
+                baz.runIt(); times = 1
+            }
+        }
+
+        when:
+        foo.bar.baz.runIt()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'cascade two levels and verify invocation on last mock only'(@Mocked Foo foo, @Mocked final Baz baz) {
+        given:
+        Baz cascadedBaz = foo.bar.baz
+
+        expect:
+        cascadedBaz.is baz
+
+        and:
+        when:
+        cascadedBaz.runIt()
+
+        and:
+        new GroovyVerifications() {
+            {
+                baz.runIt()
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    // Tests using the java.lang.Process and java.lang.ProcessBuilder classes //////////////////////////////////////////
+
+    def 'cascade on JRE classes'(@Mocked final ProcessBuilder pb) {
+        given:
+        new GroovyExpectations() {
+            {
+                ProcessBuilder sameBuilder = pb.directory(any)
+                Process process = sameBuilder.start()
+                process.getOutputStream().write 5
+                process.exitValue(); result = 1
+            }
+        }
+
+        when:
+        Process process = new ProcessBuilder('test').directory(new File('myDir')).start()
+        process.outputStream.write 5
+        process.outputStream.flush()
+
+        then:
+        process.exitValue() == 1
+    }
+
+    def 'create os process to copy temp files'(@Mocked final ProcessBuilder pb) {
+        given:
+        // Code under test creates a new process to execute an OS-specific command.
+        String cmdLine = 'copy /Y *.txt D:\\TEMP'
+        File wrkDir = new File(/C:\TEMP/)
+        Process copy = new ProcessBuilder().command(cmdLine).directory(wrkDir).start()
+
+        expect:
+        copy.waitFor() == 0
+
+        and:
+        when:
+        // Verify the desired process was created with the correct command.
+        new GroovyVerifications() {
+            {
+                pb.command(withSubstring('copy')).start()
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    // Tests using java.net classes ////////////////////////////////////////////////////////////////////////////////////
+
+    def 'record and verify expectations on cascaded mocks'(
+            @Mocked Socket anySocket, @Mocked final SocketChannel cascadedChannel, @Mocked InetSocketAddress inetAddr) {
+        given:
+        Socket sk = new Socket()
+        SocketChannel ch = sk.channel
+
+        if (!ch.connected) {
+            SocketAddress sa = new InetSocketAddress('remoteHost', 123)
+            ch.connect sa
+        }
+
+        expect:
+        !sk.inetAddress.is(sk.localAddress)
+
+        and:
+        when:
+        new GroovyVerifications() {
+            {
+                cascadedChannel.connect withNotNull()
+            }
+        }
+
+        then:
+        noExceptionThrown()
+    }
+
+    @Stepwise
+    @Title('Cascading Parameters Socket Sub Specification')
+    public static final class CascadingParametersSocketSubSpecification extends Specification {
+        static final class SocketFactory {
+            public Socket createSocket() { return new Socket() }
+
+            public Socket createSocket(String host, int port) throws IOException {
+                return new Socket(host, port)
+            }
+        }
+
+        def 'mock dynamically a class to be later mocked through cascading'() {
+            given:
+            new GroovyExpectations(Socket) {}
+        }
+
+        def 'cascade one level with argument matchers'(@Mocked final SocketFactory sf) {
+            given:
+            new GroovyExpectations() {
+                {
+                    sf.createSocket anyString, 80; result = null
+                }
+            }
+
+            expect:
+            !sf.createSocket('expected', 80)
+            sf.createSocket 'unexpected', 8080
+        }
+
+        def 'record and verify one level deep'(@Mocked final SocketFactory sf) {
+            given:
+            final OutputStream out = new ByteArrayOutputStream()
+
+            and:
+            new GroovyExpectations() {
+                {
+                    sf.createSocket().getOutputStream(); result = out
+                }
+            }
+
+            expect:
+            sf.createSocket().outputStream.is out
+        }
+
+        def 'record and verify on two cascading mocks of the same type'(
+                @Mocked final SocketFactory sf1, @Mocked final SocketFactory sf2) {
+            given:
+            final OutputStream out1 = new ByteArrayOutputStream()
+            final OutputStream out2 = new ByteArrayOutputStream()
+
+            and:
+            new GroovyExpectations() {
+                {
+                    sf1.createSocket().getOutputStream(); result = out1
+                    sf2.createSocket().getOutputStream(); result = out2
+                }
+            }
+
+            expect:
+            sf1.createSocket().outputStream.is out1
+            sf2.createSocket().outputStream.is out2
+
+            and:
+            when:
+            new GroovyFullVerificationsInOrder() {
+                {
+                    sf1.createSocket().outputStream
+                    sf2.createSocket().outputStream
+                }
+            }
+
+            then:
+            noExceptionThrown()
+        }
+
+        def 'record and verify same invocation on mocks returned from invocations with different arguments'(
+                @Mocked final SocketFactory sf) {
+            given:
+            new GroovyExpectations() {
+                {
+                    sf.createSocket().getPort(); result = 1
+                    sf.createSocket('first', 80).getPort(); result = 2
+                    sf.createSocket('second', 80).getPort(); result = 3
+                    sf.createSocket(anyString, 81).getPort(); result = 4
+                }
+            }
+
+            expect:
+            sf.createSocket().port == 1
+            sf.createSocket('first', 80).port == 2
+            sf.createSocket('second', 80).port == 3
+            sf.createSocket('third', 81).port == 4
+
+            and:
+            when:
+            new GroovyVerificationsInOrder() {
+                {
+                    sf.createSocket().port; times = 1
+                    sf.createSocket('first', 80).port
+                    sf.createSocket('second', 80).port
+                    sf.createSocket(anyString, 81).port; maxTimes = 1
+                    sf.createSocket('fourth', -1); times = 0
+                }
+            }
+
+            then:
+            noExceptionThrown()
+        }
+
+        def 'cascade on inherited method'(@Mocked SocketChannel sc) {
+            expect:
+            sc.provider()
+        }
+
+        def 'record and verify with mixed cascade levels'(@Mocked final SocketFactory sf) {
+            given:
+            new GroovyExpectations() {
+                {
+                    sf.createSocket('first', 80).getKeepAlive(); result = true
+                    sf.createSocket(withEqual('second'), anyInt).getChannel().close(); times = 1
+                }
+            }
+
+            and:
+            sf.createSocket('second', 80).channel.close()
+
+            expect:
+            sf.createSocket('first', 80).keepAlive
+
+            and:
+            when:
+            sf.createSocket('first', 8080).channel.provider().openPipe()
+
+            and:
+            new GroovyVerifications() {
+                {
+                    sf.createSocket('first', 8080).channel.provider().openPipe()
+                }
+            }
+
+            then:
+            noExceptionThrown()
+        }
+    }
+
+    def 'record strict expectation on cascaded mock'(@Mocked Foo foo, @Mocked final Bar mockBar) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mockBar.doSomething()
+            }
+        }
+
+        when:
+        foo.bar.doSomething()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'record expectation on cascaded mock'(@Mocked Foo foo, @Mocked final Bar mockBar) {
+        given:
+        new GroovyExpectations() {
+            {
+                mockBar.doSomething(); times = 1; result = 123
+            }
+        }
+
+        expect:
+        foo.bar.doSomething() == 123
+    }
+
+    def 'override two cascaded mocks of the same type'(
+            @Mocked final Foo foo1, @Mocked final Foo foo2, @Mocked final Bar mockBar1, @Mocked final Bar mockBar2) {
+        given:
+        new GroovyExpectations() {
+            {
+                foo1.getBar(); result = mockBar1
+                foo2.getBar(); result = mockBar2
+                mockBar1.doSomething()
+                mockBar2.doSomething()
+            }
+        }
+
+        when:
+        foo1.bar.doSomething()
+        foo2.bar.doSomething()
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'override two cascaded mocks of the same type but replay in different order'(
+            @Mocked final Foo foo1,
+            @Mocked final Foo foo2, @Injectable final Bar mockBar1, @Mocked final Bar mockBar2) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                foo1.getBar(); result = mockBar1
+                foo2.getBar(); result = mockBar2
+                mockBar1.doSomething()
+                mockBar2.doSomething()
+            }
+        }
+
+        when:
+        Bar bar1 = foo1.bar
+        Bar bar2 = foo2.bar
+        bar2.doSomething()
+        bar1.doSomething()
+
+        then:
+        thrown UnexpectedInvocation
+    }
+
+    def 'cascaded enum'(@Mocked final Foo mock) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.getBar().getEnum(); result = AnEnum.Second
+            }
+        }
+
+        expect:
+        mock.bar.enum == AnEnum.Second
+    }
+
+    def 'cascaded enum returning consecutive values through result field'(@Mocked final Foo mock) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.getBar().getEnum()
+                result = AnEnum.First
+                result = AnEnum.Second
+                result = AnEnum.Third
+            }
+        }
+
+        expect:
+        mock.bar.enum == AnEnum.First
+        mock.bar.enum == AnEnum.Second
+        mock.bar.enum == AnEnum.Third
+    }
+
+    def 'cascaded enum returning consecutive values through returns method'(@Mocked final Foo mock) {
+        given:
+        new GroovyExpectations() {
+            {
+                mock.getBar().getEnum()
+                returns AnEnum.First, AnEnum.Second, AnEnum.Third
+            }
+        }
+
+        expect:
+        mock.bar.enum == AnEnum.First
+        mock.bar.enum == AnEnum.Second
+        mock.bar.enum == AnEnum.Third
+    }
+
+    def 'cascaded strict enum returning consecutive values through result field'(@Mocked final Foo mock) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.getBar().getEnum()
+                result = AnEnum.Third
+                result = AnEnum.Second
+                result = AnEnum.First
+            }
+        }
+
+        and:
+        Bar bar = mock.bar
+
+        expect:
+        bar.enum == AnEnum.Third
+        bar.enum == AnEnum.Second
+        bar.enum == AnEnum.First
+    }
+
+    def 'cascaded strict enum returning consecutive values through returns method'(@Mocked final Foo mock) {
+        given:
+        new GroovyStrictExpectations() {
+            {
+                mock.getBar().getEnum()
+                returns AnEnum.First, AnEnum.Second, AnEnum.Third
+            }
+        }
+
+        and:
+        Bar bar = mock.bar
+
+        expect:
+        bar.enum == AnEnum.First
+        bar.enum == AnEnum.Second
+        bar.enum == AnEnum.Third
+    }
+
+    def 'override last cascaded object with non mocked instance'(@Mocked final Foo foo) {
+        given:
+        final Date newDate = new Date(123)
+
+        expect:
+        newDate.time == 123
+
+        and:
+        when:
+        new GroovyExpectations() {
+            {
+                foo.getBar().getBaz().getDate()
+                result = newDate
+            }
+        }
+
+        then:
+        new Foo().bar.baz.date.is newDate
+        newDate.time == 123
+    }
+
+    def 'return Declared Mocked Instance From Multi Level Cascading'(@Mocked Date mockedDate, @Mocked Foo foo) {
+        given:
+        Date newDate = new Date(123)
+
+        expect:
+        newDate.time == 0
+
+        and:
+        when:
+        Date cascadedDate = new Foo().bar.baz.date
+
+        then:
+        cascadedDate.is mockedDate
+        newDate.time == 0
+        mockedDate.time == 0
+    }
+
+    def 'return injectable mock instance from multi level cascading'(@Injectable Date mockDate, @Mocked Foo foo) {
+        given:
+        Date newDate = new Date(123)
+
+        expect:
+        newDate.time == 123
+
+        and:
+        when:
+        Date cascadedDate = new Foo().bar.baz.date
+
+        then:
+        cascadedDate.is mockDate
+        newDate.time == 123
+        mockDate.time == 0
+    }
+
+    static class Factory {
+        static Factory create() { null }
+    }
+
+    static class Client {
+        OtherClient getOtherClient() { null }
+    }
+
+    static class OtherClient {
+        static final Factory F = Factory.create()
+    }
+
+    def 'cascade during static initialization of cascading class'(@Mocked Factory mock1, @Mocked Client mock2) {
+        expect:
+        mock2.otherClient
+        OtherClient.F
+    }
+
+    public interface LevelZero {
+        Runnable getFoo()
+    }
+
+    public interface LevelOne extends LevelZero {}
+
+    public interface LevelTwo extends LevelOne {}
+
+    def 'create cascaded mock from method defined two levels up an interface hierarchy'(@Mocked LevelTwo mock) {
+        expect:
+        mock.foo
+    }
+
+    public abstract class AbstractClass implements LevelZero {}
+
+    def 'cascade type returned from interface implemented by abstract class'(@Mocked AbstractClass mock) {
+        expect:
+        mock.foo
+    }
+
+    def 'produce different cascaded instances of same interface from different invocations'(@Mocked Bar bar) {
+        given:
+        Baz cascaded1 = bar.getBaz 1
+        Baz cascaded2 = bar.getBaz 2
+        Baz cascaded3 = bar.getBaz 1
+
+        expect:
+        cascaded3.is cascaded1
+        !cascaded2.is(cascaded1)
+    }
+
+    def 'cascade from java management API'(@Mocked ManagementFactory mngmntFactory) {
+        given:
+        CompilationMXBean compilation = ManagementFactory.compilationMXBean
+
+        expect:
+        compilation
+        !compilation.name
+    }
+}

--- a/main/test/mockit/CascadingParametersTest.java
+++ b/main/test/mockit/CascadingParametersTest.java
@@ -87,9 +87,11 @@ public final class CascadingParametersTest
    public void verifyThatPreviousCascadedInstancesHaveBeenDiscarded(@Mocked Foo foo)
    {
       Bar bar = foo.getBar();
+      assertNotNull(cascadedBar1);
       assertNotSame(cascadedBar1, bar);
 
       Bar globalBar = Foo.globalBar();
+      assertNotNull(cascadedBar2);
       assertNotSame(cascadedBar2, globalBar);
    }
 

--- a/main/test/mockit/ServiceDoSomething.java
+++ b/main/test/mockit/ServiceDoSomething.java
@@ -1,0 +1,22 @@
+package mockit;
+
+import java.lang.reflect.*;
+
+public interface ServiceDoSomething {
+   int doSomething();
+
+   class ServiceDoSomethingProvider {
+      static ServiceDoSomething newProxyClassAndInstance(Class<?>... interfacesToImplement) {
+         ClassLoader loader = ServiceDoSomething.class.getClassLoader();
+
+         return (ServiceDoSomething) Proxy.newProxyInstance(loader, interfacesToImplement, new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws NoSuchMethodException {
+               throw new RuntimeException("Should be mocked out");
+            }
+         });
+      }
+
+      static ServiceDoSomething proxyInstance;
+   }
+}


### PR DESCRIPTION
Hi, what do you think about the support of
- testing Groovy code with JMockit
- writing tests in Groovy with JMockit
- properly supporting the Spock testing framework

**This PR is not yet ready to be pulled**
It is just a work in progress for you to have a first look at it
and to prevent me from too much effort to port all tests if you will
not accept the PR in any case anyway.

As I am touching the guts of JMockit here, I would really like to get
some feedback from you about my changes.

**Background:**

I prepared a pull request for a Gradle plugin which is written in Groovy
and wrote tests for my changes in Spock. Then I came to one point where
I needed to mock a static method call which is not possible with Spock-included
mocking, like in all other JDK-proxy and cglib-proxy based mocking frameworks.

As I knew JMockit well, I thought I could use it for mocking this call.

Actually it worked fine, as I had only one very limited use of a JMockit MockUp
which worked fine in my case. But as I played around with JMockit in Spock tests
I rather soon found that it neither works good to test Groovy code, nor to write
tests in Groovy, nor to use Spock features when also using JMockit, so I thought
I give it a shot and have a look whether I could improve on this.

**Here some more details and current limitations**

I started making JMockit properly hook into the Spock lifecycle and then started
to rewrite the existing JUnit tests in Spock. This tests all three aspects, testing
Groovy code (the testees are in the test classes like for the JUnit tests), writing
tests in Groovy (Spock tests _are_ Groovy code) and testing with Spock.

While porting the first few tests I found some more issues to fix, but I found out
how to do most of it properly and currently I seldomly get new tests failing but
just porting one after the other, so I thought it might be time for a wip-preview.

_Specifics when writing tests in Groovy_

Due to the fancy magic Groovy does to provide its dynamic language features,
Invocations subclass redefinition cannot be used properly if the subclass is written
in Groovy. Especially the special handling for field accesses to the any-fields
and the field assignments to result, times, minTimes and maxTimes which are rewritten
by JMockit during class redefinition time. Other things like calling
ActiveInvocations.endInvocations() at the end of the constructor work fine though.

But as the Groovy dynamicness is the problem, it is the solution at the same time.
When writing your tests in Groovy, you should use the Groovy-prefixed subclasses of
the respective Invocations subclass instead which will use Groovy magic to translate
the property reads and writes to the according ActiveInvocations calls. If not using
any of the any-fields and special assignment fields, you should be able to also use
the non-Groovy-prefixed classes, it shouldn't make any difference in that case.

Other than that there is no Groovy specific thing to keep in mind that I have in mind
right now.

_Spock specifics_

You might say Spock tests are just JUnit tests that run with a special Runner. But this
is not true. It is correct that for easy adoption Spock tests are usually started by
a special Runner as JUnit test, but only that each tool and environment that supports
JUnit already automatically supports Spock out-of-the box too without any effort and
that you can easily mix JUnit and Spock tests to be able to have a slow transition
phase instead of a big-boom switch in case you already have a lot of JUnit tests.

Other than that Spock is much different from JUnit. It has its own lifecycle with hooks
to attach to and so on. This is also one of the most important points here why a
dedicated Spock support is necessary, as the Spock lifecycle does not map 1:1 to the
JUnit lifecycle. A feature method in Spock is the according thing to a test method in
JUnit, but the point is, that a feature method in Spock can run multiple times with
a different set of data (this is called multiple iterations).

And this is also the point where the Junit 4 JMockit integration fails. If you have a
data-driven feature method and you define a MockUp in it, then you get an already mocked
error when the second iteration is run, as the MockUp is not cleaned up properly around
an iteration.

When writing the Spock extension I took the JUnit 5 integration as of JMockit 1.28 as
example as you have similar possibilities to hook into various places of the lifecycle.
In case of Spock this is not realized with listeners or callbacks, but with interceptors.
You can hook interceptors around various things in the Spock lifecyle. As there is no
developer documentation for Spock yet, I created a graphic that shows which interceptors
are possible and how they are wrapped around each other as of my knowledge. After the
image I will describe which interceptors I used in the JMockitExtension, maybe you can
tell me whether I used the correct ones or whether there are better places to do some
of the things? You can see the concrete code in the changes of this PR.

![spock_interceptors](https://cloud.githubusercontent.com/assets/325196/19748337/3e41ea80-9be1-11e6-9608-38907ccc6f74.png)

For each interception point there can of course be multiple interceptors added by arbitrary
Spock extensions. Their order is currently depending on the order they are added, but there
should not be made any order assumptions within one interception point I think.
Where you see three dots, that means that the block before can be repeated an arbitrary
amount of times.
The "... method interceptors" are of course only run if there are actual methods of this
type to be executed (the white boxes) and those can inject parameters to be given to the
method that will be run.
If you wonder what the difference is between shared initializer interceptor and shared
initializer method interceptor and between initializer interceptor and initializer method
interceptor as there can be at most one of those methods each, there are only the two methods
if there are @Shared respectively non-@Shared fields that get values assigned at declaration
time. The compiler will put those initializations in a generated method and call it at the
proper place in the lifecycle. So if there are no such initializations, no method is generated
and thus the method interceptor is never called. The non-method interceptors are always called
at the proper place in the lifecycle to do work that has to be done at that time.

As basic mapping to JUnit terms, a specification is a test class and a feature is a test
method. In Spock you have a good support for parameterized tests, so a feature method can
be run multiple times with a different set of data each such run is called iteration. For
each iteration (big green block) you get an own instance of the test class for encapsulation
of test runs like in JUnit.

In the JMockitExtension I call initializeIfPossible() in the start() method that is run
once for a Spock run overall. Then I add a specification interceptor, an initializer
interceptor, an iteration interceptor and a feature method interceptor that are handled
in the likewise named methods. The invocation.proceed() call is the point where delegation
happens and "before" is separated from "after". I will probably add one more, a shared
initializer interceptor that will in its after-phase fill @Shared mock fields like the
initializer interceptor that fills the non-@Shared mock fields.

_Current Limitations I am aware of_

As Groovy does some fancy magic in the compiled class files to provide its dynamic
language features, some things cannot be done easily like for respective Java classes.
This is mostly related to the redefinition of the Invocations subclasses, as there
are no simple method calls and property accesses in the code generated by the Groovy
compiler.
- unmockable call checks do not work. If unmockable calls are used and then some
  constraint is set, either 'java.lang.IllegalStateException: Missing invocation
  to mocked type at this point; please make sure such invocations appear only after
  the declaration of a suitable mock field or parameter' is thrown if there was no
  mocked call before, or the mocked call before is modified instead (cannot be changed probably)
- concrete arguments and argument matchers (including any-fields) must not be mixed,
  either all concrete or all matchers have to be used (use withEqual(concreteValue)
  if matchers are needed). The only exception is if all matchers come first and then
  all concrete values. The problem here is, that the move calls for the matchers cannot
  be done as the argument position is not known for the matcher, so matchers always
  slide to the first positions, just like with using matchers in var-args parameters.
  (cannot be changed probably)
- no argument capturing can be used. Up to now I found no way how to do the argument
  capturing the Groovy way. I am not sure wether this can maybe made possible somehow,
  I did not stuff too much energy into this point yet.
- special care has to be taken when using data driven methods if you use JMockit-annotated
  parameters in feature methods that are data-driven. This is true for all Spock
  extensions that provide custom parameters currently, as it is not yet nicely implemented
  I have hope that this will be improved in a future version. The problems are described at
  https://github.com/spockframework/spock/issues/651 and https://github.com/spockframework/spock/issues/652.
- when mocking classes used by Groovy (i. e. groovy or jdk classes) it can happen that there
  are strange results, e. g. if you mock Callable and Groovy uses some Closures which
  effectively are Callables, this can lead to strange results. (nothing that can be done
  here, I just had it in one of the testcases and switched over to own classes in that
  case. All other Spock tests should be more or less identical to the JUnit tests)
