### PR TITLE
Provide OSGi meta-informations for JUnit 4.12

### DIFF
--- a/main/pom.xml
+++ b/main/pom.xml
@@ -107,6 +107,7 @@
             <artifactId>maven-jar-plugin</artifactId><version>2.6</version>
             <configuration>
                <archive>
+   				  <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                   <addMavenDescriptor>false</addMavenDescriptor>
                   <manifestEntries>
                      <Main-Class>mockit.coverage.CodeCoverage</Main-Class>
@@ -120,6 +121,27 @@
                </archive>
             </configuration>
          </plugin>
+		 <plugin>
+			<groupId>org.apache.felix</groupId>
+			<artifactId>maven-bundle-plugin</artifactId>
+			<version>3.3.0</version>
+			<executions>
+				<execution>
+					<id>bundle-manifest</id>
+					<phase>process-classes</phase>
+					<goals>
+						<goal>manifest</goal>
+					</goals>
+					<configuration>
+						<instructions>
+							<Export-Package>!.,mockit.internal.expectations.transformation,!*internal*,!*impl*,*</Export-Package>
+							<Import-Package>*,org.junit.runner;version="[4.12,5.0)";resolution:=optional</Import-Package>
+							<DynamicImport-Package>*</DynamicImport-Package>
+						</instructions>
+					</configuration>
+				</execution>
+			</executions>
+		 </plugin>
          <plugin>
             <artifactId>maven-source-plugin</artifactId><version>3.0.0</version>
             <configuration>


### PR DESCRIPTION
- Tested only with JUnit 4.12
- Needs additional dependency to a bundle/fragment, that exports package
sun.reflect (e.g. search for com.diffplug.osgi.extension.sun.reflect on
maven central)