### PR TITLE
Support includeTests coverage property.

### DIFF
--- a/main/src/mockit/coverage/modification/ClassSelection.java
+++ b/main/src/mockit/coverage/modification/ClassSelection.java
@@ -30,7 +30,7 @@ final class ClassSelection
 
    ClassSelection()
    {
-      testCode = TEST_CLASS_NAME.matcher("");
+      testCode = Configuration.getProperty("includeTests") != null ? null : TEST_CLASS_NAME.matcher("");
    }
 
    @Nullable


### PR DESCRIPTION
Fixes #502

Sorry that I didn't add a new test. I would of, if I could get the tests to work on my machine. I use a Mac and when I tried 'mvn clean test' against master, it failed miserably.

Note that I use this patch in my projects to get code coverage of my generated test classes and it works.