### PR TITLE
Add JDK11 NestHost + NestMembers support in ASM

### DIFF
--- a/main/src/mockit/asm/ClassReader.java
+++ b/main/src/mockit/asm/ClassReader.java
@@ -38,6 +38,8 @@ public final class ClassReader extends AnnotatedReader
    @Nonnull private String[] interfaces = NO_INTERFACES;
    @Nullable private String sourceFileName;
    @Nullable private EnclosingMethod enclosingMethod;
+   @Nullable private String nestHost;
+   @Nullable private String[] nestMembers;
    @Nonnegative private int innerClassesCodeIndex;
    @Nonnegative private int attributesCodeIndex;
 
@@ -114,6 +116,8 @@ public final class ClassReader extends AnnotatedReader
       visitor.visit(version, access, classDesc, signature, superClassDesc, interfaces);
       visitSourceFileName();
       visitOuterClass();
+      visitNestHost();
+      visitNestMembers();
       readAnnotations(visitor);
       readInnerClasses();
       readFieldsAndMethods();
@@ -159,6 +163,19 @@ public final class ClassReader extends AnnotatedReader
          return true;
       }
 
+      if ("NestHost".equals(attributeName)) {
+         nestHost = readNonnullClass();
+         return true;
+      }
+
+      if ("NestMembers".equals(attributeName)) {
+         nestMembers = new String[readShort()];
+         for (int i = 0; i < nestMembers.length; i++) {
+            nestMembers[i] = readNonnullClass();
+         }
+         return true;
+      }
+
       if ("InnerClasses".equals(attributeName)) {
          if ((flags & Flags.SKIP_INNER_CLASSES) == 0) {
             innerClassesCodeIndex = codeIndex;
@@ -191,6 +208,20 @@ public final class ClassReader extends AnnotatedReader
    private void visitOuterClass() {
       if (enclosingMethod != null) {
          cv.visitOuterClass(enclosingMethod.owner, enclosingMethod.name, enclosingMethod.desc);
+      }
+   }
+
+   private void visitNestHost() {
+      if (nestHost != null) {
+         cv.visitNestHost(nestHost);
+      }
+   }
+
+   private void visitNestMembers() {
+      if (nestMembers != null) {
+         for (String nestMember : nestMembers) {
+            cv.visitNestMember(nestMember);
+         }
       }
    }
 

--- a/main/src/mockit/asm/ClassVisitor.java
+++ b/main/src/mockit/asm/ClassVisitor.java
@@ -51,6 +51,20 @@ public class ClassVisitor extends BaseWriter
    public void visitOuterClass(@Nonnull String owner, @Nullable String name, @Nullable String desc) {}
 
    /**
+    * Visits the nest host of the class. This method must be called only if the class has a nest host.
+    *
+    * @param nestHost name of the nest host class
+    */
+   public void visitNestHost(String nestHost) {}
+
+   /**
+    * Visits the a nest member of the class. This method must be called only if the class has nest members.
+    *
+    * @param nestMember name of a nest member class
+    */
+   public void visitNestMember(String nestMember) {}
+
+   /**
     * Visits information about an inner class. This inner class is not necessarily a member of the class being visited.
     *
     * @param name      the internal name of an inner class.

--- a/main/src/mockit/asm/ClassWriter.java
+++ b/main/src/mockit/asm/ClassWriter.java
@@ -52,6 +52,8 @@ public final class ClassWriter extends ClassVisitor
    @Nullable private SignatureWriter signatureWriter;
    @Nonnull private final SourceInfoWriter sourceInfo;
    @Nullable private OuterClassWriter outerClassWriter;
+   @Nullable private NestHostWriter nestHostWriter;
+   @Nullable private NestMembersWriter nestMembersWriter;
    @Nullable private InnerClassesWriter innerClassesWriter;
    @Nullable final BootstrapMethods bootstrapMethods;
 
@@ -151,6 +153,19 @@ public final class ClassWriter extends ClassVisitor
       outerClassWriter = new OuterClassWriter(cp, owner, name, desc);
    }
 
+   @Override
+   public void visitNestHost(String nestHost) {
+      nestHostWriter = new NestHostWriter(cp, nestHost);
+   }
+
+   @Override
+   public void visitNestMember(String nestMember) {
+      if (nestMembersWriter == null) {
+         nestMembersWriter = new NestMembersWriter(cp);
+      }
+      nestMembersWriter.add(nestMember);
+   }
+
    @Nonnull @Override
    public AnnotationVisitor visitAnnotation(@Nonnull String desc) {
       return addAnnotation(desc);
@@ -214,6 +229,14 @@ public final class ClassWriter extends ClassVisitor
 
       if (outerClassWriter != null) {
          size += outerClassWriter.getSize();
+      }
+
+      if (nestHostWriter != null) {
+         size += nestHostWriter.getSize();
+      }
+
+      if (nestMembersWriter != null) {
+         size += nestMembersWriter.getSize();
       }
 
       if (innerClassesWriter != null) {
@@ -287,6 +310,14 @@ public final class ClassWriter extends ClassVisitor
 
       putMarkerAttributes(out);
 
+      if (nestHostWriter != null) {
+         nestHostWriter.put(out);
+      }
+
+      if (nestMembersWriter != null) {
+         nestMembersWriter.put(out);
+      }
+
       if (innerClassesWriter != null) {
          innerClassesWriter.put(out);
       }
@@ -305,6 +336,14 @@ public final class ClassWriter extends ClassVisitor
       }
 
       if (outerClassWriter != null) {
+         attributeCount++;
+      }
+
+      if (nestHostWriter != null) {
+         attributeCount++;
+      }
+
+      if (nestMembersWriter != null) {
          attributeCount++;
       }
 

--- a/main/src/mockit/asm/NestHostWriter.java
+++ b/main/src/mockit/asm/NestHostWriter.java
@@ -1,0 +1,24 @@
+package mockit.asm;
+
+import javax.annotation.*;
+
+final class NestHostWriter extends AttributeWriter
+{
+   @Nonnegative private final int nestHostIndex;
+
+   NestHostWriter(@Nonnull ConstantPoolGeneration cp, @Nonnull String nestHost) {
+      super(cp, "NestHost");
+      nestHostIndex = cp.newClass(nestHost);
+   }
+
+   @Nonnegative @Override
+   int getSize() {
+      return 8;
+   }
+
+   @Override
+   void put(@Nonnull ByteVector out) {
+      super.put(out);
+      out.putShort(nestHostIndex);
+   }
+}

--- a/main/src/mockit/asm/NestMembersWriter.java
+++ b/main/src/mockit/asm/NestMembersWriter.java
@@ -1,0 +1,29 @@
+package mockit.asm;
+
+import javax.annotation.Nonnull;
+
+public class NestMembersWriter extends AttributeWriter
+{
+   @Nonnull private final ByteVector nestMembers;
+
+   public NestMembersWriter(@Nonnull ConstantPoolGeneration cp) {
+      super(cp, "NestMembers");
+      nestMembers = new ByteVector();
+   }
+
+   @Override
+   int getSize() {
+      return nestMembers.length + 8;
+   }
+
+   void add(String nestMember) {
+      int index = cp.newClass(nestMember);
+      nestMembers.putShort(index);
+   }
+
+   @Override
+   void put(@Nonnull ByteVector out) {
+      put(out, nestMembers.length + 2);
+      out.putShort(nestMembers.length / 2).putByteVector(nestMembers);
+   }
+}

--- a/main/src/mockit/asm/WrappingClassVisitor.java
+++ b/main/src/mockit/asm/WrappingClassVisitor.java
@@ -37,6 +37,16 @@ public class WrappingClassVisitor extends ClassVisitor
       cw.visitOuterClass(owner, name, desc);
    }
 
+   @Override
+   public void visitNestHost(String nestHost) {
+      cw.visitNestHost(nestHost);
+   }
+
+   @Override
+   public void visitNestMember(String nestMember) {
+      cw.visitNestMember(nestMember);
+   }
+
    @Nullable @Override
    public AnnotationVisitor visitAnnotation(@Nonnull String desc) {
       return cw.visitAnnotation(desc);


### PR DESCRIPTION
JDK11 needs the NestHost class attributes to access private fields of outer class. It was introduced by the [JEP 181](http://openjdk.java.net/jeps/181).
It fixes issue #553 (and #552)