### PR TITLE
DynamicInvocationResult checks if result is assignable to targetReturnType

### DIFF
--- a/main/src/mockit/internal/expectations/invocation/DynamicInvocationResult.java
+++ b/main/src/mockit/internal/expectations/invocation/DynamicInvocationResult.java
@@ -104,7 +104,7 @@ class DynamicInvocationResult extends InvocationResult
       Object returnValue = invoke(targetObject, methodToInvoke, args);
       Class<?> fromReturnType = methodToInvoke.getReturnType();
 
-      if (returnValue == null || targetReturnType.isAssignableFrom(fromReturnType)) {
+      if (returnValue == null || targetReturnType.isInstance(returnValue)) {
          if (fromReturnType == void.class && fromReturnType != targetReturnType && targetReturnType.isPrimitive()) {
             String returnTypeName = JAVA_LANG.matcher(targetReturnType.getName()).replaceAll("");
             MethodFormatter methodDesc =

--- a/main/test/mockit/DelegateTest.java
+++ b/main/test/mockit/DelegateTest.java
@@ -28,6 +28,8 @@ public final class DelegateTest
 
    static final class Foo { int doSomething() { return 1; } }
 
+   static final class Bar { Map doSomething() { return Collections.emptyMap(); } }
+
    @Test
    public void resultFromDelegate(@Mocked final Collaborator collaborator) {
       final boolean bExpected = true;
@@ -501,6 +503,18 @@ public final class DelegateTest
       thrown.expectMessage("void return type incompatible with return type int");
 
       mock.getValue();
+   }
+
+   @Test
+   public void returnObjectInstanceOfTargetReturnTypeFromDelegateMethodForRecordedMethod(
+           @Mocked final Bar mock
+   ) {
+      new Expectations() {{
+         mock.doSomething();
+         result = new Delegate() { Object delegate() { return Collections.emptyMap();} };
+      }};
+
+      mock.doSomething();
    }
 
    @Test


### PR DESCRIPTION
Allow support to delegates using lambdas.

Given a utility class: 

```java
/**
 * Utility class to allow using lambdas with JMockit {@link Delegate}
 */
public final class DelegateUtils {

    private DelegateUtils() {
        // no-op util constructor
    }

    public static <T, R> Delegate<T> delegate(Function<T, R> function) {
        return new Delegate<T>() {
            R delegate(T t) {
                return function.apply(t);
            }
        };
    }
}
```

Allow using a lambda expression in an Expectation:

```java
new Expectations() {{
    someClass.someMethod(stringValue);
    result = DelegateUtils.delegate(MyObject::getStringValue);
}}
``` 

Due to type inference `methodToInvoke.getReturnType()` will return `Object.class` resulting in an `InvocationException`, ie: 
```
java.lang.IllegalArgumentException: Value of type java.util.Collections$EmptyMap incompatible with return type java.util.Map of mockit.DelegateTest$Bar#doSomething()
```