### PR TITLE
Fix NPE when className is null

### DIFF
--- a/main/src/mockit/internal/expectations/transformation/ExpectationsTransformer.java
+++ b/main/src/mockit/internal/expectations/transformation/ExpectationsTransformer.java
@@ -22,7 +22,7 @@ public final class ExpectationsTransformer implements ClassFileTransformer
       @Nullable ClassLoader loader, @Nonnull String className, @Nullable Class<?> classBeingRedefined,
       @Nullable ProtectionDomain protectionDomain, @Nonnull byte[] classfileBuffer
    ) {
-      if (classBeingRedefined == null && protectionDomain != null) {
+      if (classBeingRedefined == null && protectionDomain != null && className != null) {
          boolean anonymousClass = ClassNaming.isAnonymousClass(className);
 
          if (anonymousClass && !isJMockitClass(className) && !className.startsWith("org/junit/")) {


### PR DESCRIPTION
While debugging my unit test in Eclipse 2020.09 with JUnit 5.7.0 and JMockit 1.49 I faced an NPE with the following staktrace:

```
Thread [main] (Suspended (exception java.lang.NullPointerException))	
	mockit.internal.util.ClassNaming.isAnonymousClass(java.lang.String) line: 25	
	mockit.internal.expectations.transformation.ExpectationsTransformer.transform(java.lang.ClassLoader, java.lang.String, java.lang.Class<?>, java.security.ProtectionDomain, byte[]) line: 26	
	sun.instrument.TransformerManager.transform(java.lang.ClassLoader, java.lang.String, java.lang.Class<?>, java.security.ProtectionDomain, byte[]) line: 188	
	sun.instrument.InstrumentationImpl.transform(java.lang.ClassLoader, java.lang.String, java.lang.Class<?>, java.security.ProtectionDomain, byte[], boolean) line: 428	
	sun.misc.Unsafe.defineAnonymousClass(java.lang.Class<?>, byte[], java.lang.Object[]) line: not available [native method]	
	java.lang.invoke.InnerClassLambdaMetafactory.spinInnerClass() line: 326	
	java.lang.invoke.InnerClassLambdaMetafactory.buildCallSite() line: 194	
	java.lang.invoke.LambdaMetafactory.metafactory(java.lang.invoke.MethodHandles$Lookup, java.lang.String, java.lang.invoke.MethodType, java.lang.invoke.MethodType, java.lang.invoke.MethodHandle, java.lang.invoke.MethodType) line: 304	
	java.lang.invoke.LambdaForm$DMH.26117480.invokeStatic_L6_L(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object) line: not available	
	java.lang.invoke.LambdaForm$BMH.1495242910.reinvoke(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object) line: not available	
	java.lang.invoke.LambdaForm$MH.846063400.invoke_MT(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object) line: not available	
	java.lang.invoke.CallSite.makeSite(java.lang.invoke.MethodHandle, java.lang.String, java.lang.invoke.MethodType, java.lang.Object, java.lang.Class<?>) line: 302	
	java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(java.lang.Class<?>, java.lang.invoke.MethodHandle, java.lang.String, java.lang.invoke.MethodType, java.lang.Object, java.lang.Object[]) line: 307	
	java.lang.invoke.MethodHandleNatives.linkCallSite(java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object, java.lang.Object[]) line: 297	
	org.junit.platform.launcher.core.ServiceLoaderPostDiscoveryFilterRegistry.loadPostDiscoveryFilters() line: 33	
	org.junit.platform.launcher.core.LauncherFactory.create(org.junit.platform.launcher.core.LauncherConfig) line: 101	
	org.junit.platform.launcher.core.LauncherFactory.create() line: 75	
	org.eclipse.jdt.internal.junit5.runner.JUnit5TestLoader.<init>() line: 34	
	sun.reflect.NativeConstructorAccessorImpl.newInstance0(java.lang.reflect.Constructor<?>, java.lang.Object[]) line: not available [native method]	
	sun.reflect.NativeConstructorAccessorImpl.newInstance(java.lang.Object[]) line: 62	
	sun.reflect.DelegatingConstructorAccessorImpl.newInstance(java.lang.Object[]) line: 45	
	java.lang.reflect.Constructor<T>.newInstance(java.lang.Object...) line: 423	
	java.lang.Class<T>.newInstance() line: 442 [local variables unavailable]	
	org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createRawTestLoader(java.lang.String) line: 371	
	org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.createLoader(java.lang.String) line: 366	
	org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.defaultInit(java.lang.String[]) line: 310	
	org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.init(java.lang.String[]) line: 225	
	org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(java.lang.String[]) line: 209	
```