### PR TITLE
Mocks created by JUnit4 tests are not cleaned up when run with JUnit5

### DIFF
--- a/main/src/mockit/internal/startup/JMockitInitialization.java
+++ b/main/src/mockit/internal/startup/JMockitInitialization.java
@@ -31,7 +31,8 @@ final class JMockitInitialization
    }
 
    private static void applyInternalStartupFakesAsNeeded() {
-      if (searchTypeInClasspath("org.junit.runners.model.FrameworkMethod", true) != null) {
+      if (searchTypeInClasspath("org.junit.runners.model.FrameworkMethod", true) != null
+          || searchTypeInClasspath("org.junit.vintage.engine.VintageTestEngine", true) != null) {
          new FakeRunNotifier();
          new FakeFrameworkMethod();
       }


### PR DESCRIPTION
Please provide the following information:

* Version of JMockit that was used: 1.49.a (see https://github.com/JOSM/jmockit1/tree/josm-fixes )

* Description of the problem or enhancement request:
When running JUnit4 and JUnit5 tests together, JMockit does not properly cleanup after mocks are created in the JUnit4 tests.

Problem code:
https://github.com/jmockit/jmockit1/blob/master/main/src/mockit/internal/startup/JMockitInitialization.java#L34

Workaround for non-patched releases:
Create a new `mockit.internal.state.SavePoint` before each test (i.e., in a `@Before` method) and then call the rollback method in an `@After` method. See https://josm.openstreetmap.de/changeset/18551/josm/ for an example using a custom `TestRule`.


* Check the following:

 - [x] If a defect or unexpected result, JMockit project members should be able to reproduce it.
  For that, include an example test (perhaps accompanied by a Maven/Gradle build script) which
  can be executed without changes and reproduces the failure.

 - [ ] If an enhancement or new feature request, it should be justified by an example test
  demonstrating the validity and usefulness of the desired enhancement or new feature.

 - [x] The issue does not fall outside the scope of the project (for example, attempting to use
  JMockit APIs from Groovy or Scala code, or with an Android runtime).

 - [x] The JDK where the problem occurs is a final release, not a development build.